### PR TITLE
Restore logs getting started text / remove main getting started line

### DIFF
--- a/src/pages/getting-started.mdx
+++ b/src/pages/getting-started.mdx
@@ -12,9 +12,6 @@ metrics and traces from various sources such as applications, servers, and cloud
 Our platform provides real-time data analysis, powerful search capabilities, custom dashboards, 
 and alerts for issues and anomalies.
 
-If you don't yet have a Logit.io account, you can sign up for a free trial 
-on the [Logit.io homepage](https://logit.io/) and create your account.
-
 Here's how the 14-day free trial works:
 - You can create up to 3 production-ready OpenSearch and Grafana Stacks in your trial.
 - Fully featured with no maximum daily volume or data retention limits, allowing you to send as much data as you need.

--- a/src/pages/log-management/getting-started.mdx
+++ b/src/pages/log-management/getting-started.mdx
@@ -1,180 +1,108 @@
 ---
-title: Get Started Sending Logs
-description: Discover the steps you need to take to get started with ingesting logs and metrics with Filebeat in this helpful article from Logit.io.
+title: Getting Started Sending Logs
+pagination: false
+timestamp: false
+stackTypes: logs
 ---
 
-# Get Started Sending Logs
-
-Setting up, configuring and sending logs and metrics to Logstash can 
-appear to be a complicated process, this guide aims to show you that 
-by using Logit.io it is actually a simple process.
-
-### Where to start...
-
-Filebeat is the most popular tool for ingesting logs and metrics because 
-it works with minimal configuration and with a wide range of common log 
-formats. For this reason, we recommend it as a good place to start.
+## Getting Started Sending Log data
 
 <Callout type="info">
-  Remember, Filebeat doesn't cover all logging scenarios and that is why there are several 
-  different shippers available. If you don't think that Filebeat is the solution that 
-  meets your needs then please take a look at other options in our [Data Source Integrations.](/integrations)
-</Callout>
+  To successfully use this guide, you need to have already created a Logit.io account and Log Management stack. If you haven't, please click [here](/getting-started) to continue
+</ Callout>
+You can send data to your Log Management service in a few seconds by following this guide.
 
-### Installing Filebeat
+*Note*: this guide assumes you have curl installed on your computer. It is provided by default on most Linux distributions and in macOS and Windows 10 / 11. 
+To install on earlier versions of Windows you can follow the instructions [here](https://curl.se/windows/). 
 
-After you have created your first Logit.io, navigate to `Send Logs` 
-settings and then click _View All Sources_ to get started.
+If you are logged in the Logit.io API endpoint and key values you need to send data to us will be pre-populated. If you are not logged in please do so and return to this guide.
 
-As mentioned earlier, we are going to use the recommended Filebeat in our example 
-so click _Log Management_, then click _Shippers_ and finally click _Filebeat_ to continue.
+<Tabs items={["Windows", "Linux", "macOS", "DEB", "RPM"]}>
+  <Tab>
+  Remember that you will need to escape double-quote characters with a backslash in the data field as shown in the example below.
 
-<Callout type="info">
-  If you do require a shipper other than Filebeat, this is where you choose it. 
-  Choosing a shipper will show you the source wizard that explains 
-  how to get up and running with your chosen data source.
-</Callout>
+  Command Prompt:
+  ```bash copy 
+  curl -i -H "ApiKey: @apikey" -i -H "Content-Type: application/json" -H "LogType: json" https:/@logitApiEndpoint/v2 -d "{\"test-field-name\":\"test-field-value\" }"
+  ```
 
-The first section of the wizard contains instructions for installing Filebeat. 
-The instructions cover several OS so please follow the instructions for the 
-OS that you are using. There are instructions for installing Filebeat on 
-Debian, Ubuntu, Mint, CentOS, RHEL, Fedora, macOS and Windows. However, 
-if you are using a different OS to the ones listed, try the link at the 
-bottom for the downloads page to see if you can find what you require.
+  Powershell:
+  ```ps1 copy
+  curl -Method Post `
+  -Uri "https:/@logitApiEndpoint/v2" `
+  -Headers @{
+      "ApiKey" = "@apikey";
+      "Content-Type" = "application/json";
+      "LogType" = "json"
+  } `
+  -Body (@{
+      test-field-name = "test-field-value";
+  } | ConvertTo-Json)
+  ```
+  </Tab>
 
-![Filebeat](@/images/help/log-management/sending-data/filebeat.png)
+  <Tab>
+  ```bash copy
+  curl -i -H "ApiKey: @apikey" -i -H "Content-Type: application/json"\
+  -H "LogType: json" https:/@logitApiEndpoint/v2\
+  -d '{"test-field-name":"test-field-value" }'
+  ```
+  </Tab>
 
-Next, you need to locate the configuration file, the wizard shows you where to 
-find this file for each type of OS. Click the "next step" button to do this.
+  <Tab>
+  ```bash copy
+  curl -i -H "ApiKey: @apikey" -i -H "Content-Type: application/json"\
+  -H "LogType: json" https:/@logitApiEndpoint/v2\
+  -d '{"test-field-name":"test-field-value" }'
+  ```
+  </Tab>
 
-### Configuring the inputs
+  <Tab>
+  ```bash copy
+  curl -i -H "ApiKey: @apikey" -i -H "Content-Type: application/json"\
+  -H "LogType: json" https:/@logitApiEndpoint/v2\
+  -d '{"test-field-name":"test-field-value" }'
+  ```
+  </Tab>
 
-We need to open the configuration file and make some changes. These changes are 
-also described in the source wizard. Search for the filebeat.inputs section. 
-You will see the following two lines in the file:
+  <Tab>
+  ```bash copy
+  curl -i -H "ApiKey: @apikey" -i -H "Content-Type: application/json"\
+  -H "LogType: json" https:/@logitApiEndpoint/v2\
+  -d '{"test-field-name":"test-field-value" }'
+  ```
+  </Tab>
 
-```yaml
-# Change to true to enable this input configuration.
-enabled: false
-```
-Change the enabled to true. It should now look as follows:
+  </Tabs>
 
-```yaml
-# Change to true to enable this input configuration.
-enabled: true
-```
+  ### Response
 
-You will also see the following lines in the filebeat.inputs section:
+  You should expect to receive a 202 ACCEPTED response code for a successful message
 
-```yaml
-# Paths that should be crawled and fetched. Glob based paths.
-paths:
-  - /var/log/*.log
-  #- c:\programdata\elasticsearch\logs\*
-```
+  ```cmd
+  HTTP/1.1 202 ACCEPTED
+  Content-Type: application/json
+  Content-Length: 39
+  Connection: keep-alive
+  Server: Logit-API-Server
+  Date: Wed, 27 Mar 2024 14:34:39 GMT
+  Access-Control-Allow-Origin: *
+  Strict-Transport-Security: max-age=31536000; includeSubDomains
+  X-Xss-Protection: 1; mode=block
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: SAMEORIGIN
+  {"message":"Message Received, Thanks"}
+  ```
 
-This is how you tell Filebeat where the files that you wish to ingest are located. 
-Filebeat is currently looking in the directory */var/log/* for files. 
-The Asterisk means it is looking for all files in this directory with the .log 
-extension but it is possible to be more specific and actually name the files 
-here if this is what you want to do. Change this to point to where your log files are located.
+To view the data you have just sent please click on the button below
 
-Let's now skip forward to the configure output section of the wizard. 
-Click the "Next step" button until you arrive at this section.
+<LaunchVisualizer />
 
-### Configure Output
+That's it! You have sent data to your stack and viewed it in an Opensearch Dashboard. This is, of course, just the beginning. For more help sending data 
+to your stack check out the following resources and if you need more help please feel free to contact us via Intercom.
 
-In this example, we are sending data to Logstash rather than OpenSearch so we 
-must comment out all of the lines in the configuration file that relate 
-to OpenSearch. Commenting out is done using the hash symbol. The OpenSearch 
-output section of the configuration file should look as follows:
-
-```yaml
-# output.elasticsearch:
-# Array of hosts to connect to.
-#  hosts: ["localhost:9200"]
-# Optional protocol and basic auth credentials.
-# protocol: "https"
-# username: "elastic"
-# password: "changeme"
-```
-
-Now we need to update the Logstash output section of the configuration 
-file to include your settings. You will notice that the wizard actually 
-displays your unique settings to save you from looking them up.
-
-Currently, the hosts line in the configuration file will look as follows:
-
-```yaml
-#hosts: ["localhost:5044"]
-```
-
-You need to remove the hash and then copy over the localhost part 
-with the settings shown in the wizard so that it looks similar to below:
-
-```yaml
-hosts: ["11111111-aaaa-1111-1111-111111111111-ls.logit.io:0"]
-```
-
-You then need to add the following two lines to the section:
-```yaml
-loadbalance: true
-ssl.enabled: true
-```
-When finished, the Logstash output section of the configuration 
-file should look similar to the following:
-
-```yaml
-#output.logstash:
-# The Logstash hosts
-hosts: ["11111111-aaaa-1111-1111-111111111111-ls.logit.io:0"]
-# Optional SSL. By default is off.
-# List of root certificates for HTTPS server verifications
-#ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
-# Certificate for SSL client authentication
-#ssl.certificate: "/etc/pki/client/cert.pem"]
-# Client Certificate Key
-#ssl.key: "/etc/pki/client/cert.key"]
-loadbalance: true
-ssl.enabled: true
-```
-
-Now we are ready to validate the file. Click "Next step" to do this.
-
-### Validate Configuration
-
-This section shows us how to check that the updates we have made to the 
-configuration file during the configuration process haven't broken the format. 
-Again there are instructions for several OS's so follow the instructions for 
-the one that you are using. If the validation fails then go back to the 
-Configuring Inputs and Configuring Outputs sections and check that your 
-file is in the same format as the example shown.
-
-When the validation has passed we are ready to start ingesting data. 
-Click the "Next step" button to learn how to start doing this.
-
-### Start Filebeat
-There are instructions that show how to start Filebeat for each type of OS. 
-Follow the instructions for the system that you are using.
-
-### Confirm data is in OpenSearch
-
-Having followed the instructions we should now be able to view the logs. 
-To do this click the _Launch Logs_ button for your stack.
-
-<Callout type="info">
-  OpenSearch Dashboard and Grafana are the tools that you will use to 
-  visualise your data, we can use them to see any logs and metrics that 
-  have been sent to OpenSearch on this stack.
-</Callout>
-
-When OpenSearch Dashboards is launched you should be able to see the logs 
-and metrics that were ingested into OpenSearch by Logstash. It is possible 
-to filter this data by time, fields, and content, so feel free to explore!
-
-### Troubleshooting?
-
-If you don't see any logs or metrics in OpenSearch Dashboards and/or Grafana then there are a few things that you should check.
-- Are there any files in the folder that was added during file inputs configuration?
-- Is the format of the configuration file correct? Does it validate?
-- Do the Logstash settings in the file match the settings in the source wizard? Have they been copied correctly?
+<Cards>
+  <Card title="View Data Source Integrations" href="/integrations" />
+  <Card title="Send Metrics" href="/infrastructure-metrics/getting-started" />
+  <Card title="Send Traces" href="/application-performance-monitoring/getting-started" />
+</Cards>


### PR DESCRIPTION
The contents of the Getting Started sending Logs file had been inadvertly replaced by the old version and in the main Getting Started doc there was an unnecessary line about creating a new trial.