### PR TITLE
Lengthening meta descriptions

### DIFF
--- a/src/pages/account-administration/account-access-users-teams/roles-access/change-user-authentication-type.mdx
+++ b/src/pages/account-administration/account-access-users-teams/roles-access/change-user-authentication-type.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to Change User or Authentication Type on Logit.io
-description: Learn how to Change User or Authentication Type on Logit.io
+description: As an existing user of Logit.io, you may need to change your user type for various reasons. Learn how to Change User or Authentication Type on Logit.io
 ---
 
 # How to Change User or Authentication Type on Logit.io

--- a/src/pages/account-administration/account-access-users-teams/roles-access/opensearch-custom-role.mdx
+++ b/src/pages/account-administration/account-access-users-teams/roles-access/opensearch-custom-role.mdx
@@ -1,6 +1,6 @@
 ---
 title: Using the OpenSearch Custom Role to manage granular access to your Stack
-description: Learn how to use OpenSearch Security to manage granular access to your Stack
+description: OpenSearch Custom Role allows you to decide very granular permissions directly. Learn how to use OpenSearch Security to manage granular access to your Stack.
 ---
 
 # Using the OpenSearch Custom Role to manage granular access to your Stack

--- a/src/pages/account-administration/account-access-users-teams/roles-access/sign-in-sso.mdx
+++ b/src/pages/account-administration/account-access-users-teams/roles-access/sign-in-sso.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to Sign In via Single Sign On
-description: Sign in to Logit.io with Single Sign on (SSO)
+description: SSO allows a user to authenticate in one central location and then sign into other applications automatically. Sign in to Logit.io with Single Sign on (SSO).
 ---
 
 # How to Sign In via Single Sign On

--- a/src/pages/account-administration/account-access-users-teams/two-factor-authentication/using-google-authenticator-for-2fa.mdx
+++ b/src/pages/account-administration/account-access-users-teams/two-factor-authentication/using-google-authenticator-for-2fa.mdx
@@ -1,5 +1,5 @@
 ---
-title: Using Google Authenticator for Two Factor Authentication with your Logit.io account
+title: Google Authenticator for Two Factor Authentication
 description: Read our help article to learn how to add extra security to your account and set up Google Authenticator for Two Factor Authentication (2FA) with Logit.io.
 ---
 

--- a/src/pages/account-administration/subscriptions-management-usage/accounts/what-happens-when-my-trial-ends.mdx
+++ b/src/pages/account-administration/subscriptions-management-usage/accounts/what-happens-when-my-trial-ends.mdx
@@ -1,6 +1,6 @@
 ---
 title: What Happens When My Trial Ends
-description: Will my stacks be deleted or can I continue the service uninterrupted?
+description: If you've not added a payment method to your account then your stacks will be deleted and all associated data sent will be removed.
 ---
 
 # What happens at the end of my trial?

--- a/src/pages/account-administration/subscriptions-management-usage/billing/how-to-change-email-invoice.mdx
+++ b/src/pages/account-administration/subscriptions-management-usage/billing/how-to-change-email-invoice.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to Change the Email for Invoicing
-description: Learn how to change and/or update the emails that receive invoices
+description: Read Logit.io’s help article to learn how to manage your team and change and/or update which emails receive invoices
 ---
 
 # How to Change the Email for Invoicing

--- a/src/pages/account-administration/subscriptions-management-usage/billing/how-to-change-email-overusage.mdx
+++ b/src/pages/account-administration/subscriptions-management-usage/billing/how-to-change-email-overusage.mdx
@@ -1,6 +1,6 @@
 ---
 title: Can I change the email for overusage emails?
-description: Learn how to change and/or update the emails that receive overusage emails
+description: Read Logit.io’s detailed help article to learn how to change and/or update the emails that receive overusage emails
 ---
 
 # Can I change the email for overusage emails?

--- a/src/pages/account-administration/subscriptions-management-usage/product/archiving-data-after-retention-timeframe-ended.mdx
+++ b/src/pages/account-administration/subscriptions-management-usage/product/archiving-data-after-retention-timeframe-ended.mdx
@@ -1,5 +1,5 @@
 ---
-title: How can I archive my logs, data and metrics after my retention timeframe has ended?
+title: Archive Data After Retention Timeframe Has Ended
 description: Is it possible to keep my logs, data and metrics indefinitely and how can I restore my data again in the future?
 ---
 

--- a/src/pages/account-administration/subscriptions-management-usage/product/how-logit-calculates-usage.mdx
+++ b/src/pages/account-administration/subscriptions-management-usage/product/how-logit-calculates-usage.mdx
@@ -1,6 +1,6 @@
 ---
 title: How Logit.io calculates daily index sizes and used volume statistics
-description: Learn about used volume statistics and how they relate to index sizes for the current day
+description: Read Logit.io’s help article to learn about used volume statistics and how they relate to index sizes for the current day
 ---
 
 # How Logit.io calculates daily index sizes and used volume statistics

--- a/src/pages/account-administration/subscriptions-management-usage/product/how-to-add-plugins.mdx
+++ b/src/pages/account-administration/subscriptions-management-usage/product/how-to-add-plugins.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to add plugins
-description: Learn how to add plugins to Logit.io to add further extensibility to your stacks
+description: Read our detailed help article to learn how to add plugins to Logit.io and add further extensibility to your stacks
 ---
 
 # How to add a plugin to Logit.io

--- a/src/pages/account-administration/subscriptions-management-usage/product/viewing-stack-usage-daily-log-volume.mdx
+++ b/src/pages/account-administration/subscriptions-management-usage/product/viewing-stack-usage-daily-log-volume.mdx
@@ -1,6 +1,6 @@
 ---
 title: How can I view my Logit.io ELK stack usage and daily log volume?
-description: Discover how Logit.io calculates your Elasticsearch stack disk usage in our helpful guide.
+description: Read Logit.io’s informative help article to learn how Logit.io calculates your Elasticsearch stack disk usage.
 ---
 
 # How can I view my Logit.io ELK stack usage and daily log volume?

--- a/src/pages/account-administration/subscriptions-management-usage/product/what-happens-to-data-retention-period-passes.mdx
+++ b/src/pages/account-administration/subscriptions-management-usage/product/what-happens-to-data-retention-period-passes.mdx
@@ -1,6 +1,6 @@
 ---
 title: What happens to my data after the retention period has passed?
-description: Learn what how we securely remove your data after your plan retention timeframe has ended
+description: Read Logit.io’s help article to learn how we securely remove your data after your plan retention timeframe has ended
 ---
 
 # What happens to my data after the retention period has passed?

--- a/src/pages/application-performance-monitoring/getting-started.mdx
+++ b/src/pages/application-performance-monitoring/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Started Sending Traces
-description: Discover the steps you need to take to get started sending traces to Logit.io.
+description: This guide shows the process of utilizing OpenTelemetry to ship APM traces to Jaeger via Logit.io. Discover how to get started sending traces to Logit.io.
 ---
 
 # Get Started Sending Traces

--- a/src/pages/application-performance-monitoring/ingestion-pipeline/calculating-span-ingestion.mdx
+++ b/src/pages/application-performance-monitoring/ingestion-pipeline/calculating-span-ingestion.mdx
@@ -1,6 +1,6 @@
 ---
 title: Calculating Span Ingestion
-description: Learn how Logit.io calculates tracing & span ingestion
+description: Span ingestion is collecting and incorporating trace data, into a monitoring or observability system. Learn how Logit.io calculates tracing & span ingestion
 ---
 
 # How does Logit.io calculate span ingestion?

--- a/src/pages/application-performance-monitoring/ingestion-pipeline/overview.mdx
+++ b/src/pages/application-performance-monitoring/ingestion-pipeline/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Learn about APM ingestion pipelines in Logit.io
+description: An ingestion pipeline collects, processes, and stores data from your apps and systems for monitoring and analysis. Learn about Logit.io APM ingestion pipelines
 ---
 
 # APM Ingestion Pipeline Overview

--- a/src/pages/application-performance-monitoring/jaeger/span-types.mdx
+++ b/src/pages/application-performance-monitoring/jaeger/span-types.mdx
@@ -1,6 +1,6 @@
 ---
 title: Span Types
-description: Learn how to differentiate between different span types in Jaeger with our helpful guide
+description: Categorizing and differentiating spans based on their type is crucial. Learn how to differentiate between different span types in Jaeger with our helpful guide
 ---
 
 # How can I differentiate between different span types in Jaeger?

--- a/src/pages/application-performance-monitoring/jaeger/viewing-spans-and-traces.mdx
+++ b/src/pages/application-performance-monitoring/jaeger/viewing-spans-and-traces.mdx
@@ -1,6 +1,6 @@
 ---
 title: Viewing Spans & Traces
-description: Learn how to use Jaeger to view your spans & traces in Logit.io
+description: Read our detailed help article to learn how to effectively use Jaeger to view your spans & traces in Logit.io
 ---
 
 # How to view your spans & traces?

--- a/src/pages/application-performance-monitoring/statistics.mdx
+++ b/src/pages/application-performance-monitoring/statistics.mdx
@@ -1,6 +1,6 @@
 ---
 title: Statistics
-description: Learn how APM usage statistics are calculated in Logit.io
+description: Read our help article to learn how Application Performance Monitoring (APM)  usage statistics are calculated in Logit.io
 ---
 
 # Application Performance Monitoring Statistics

--- a/src/pages/application-performance-monitoring/storage.mdx
+++ b/src/pages/application-performance-monitoring/storage.mdx
@@ -1,6 +1,6 @@
 ---
 title: Storage
-description: Learn how to view and monitor your APM storage in Logit.io
+description: Read our detailed help article to learn how to view and monitor your application performance monitoring (APM) storage in Logit.io
 ---
 
 ### What is APM Storage?

--- a/src/pages/application-performance-monitoring/troubleshooting/stack-connectivitiy.mdx
+++ b/src/pages/application-performance-monitoring/troubleshooting/stack-connectivitiy.mdx
@@ -1,5 +1,5 @@
 ---
-title: Check Connection from Infrastructure to Logit.io Stack
+title: Infrastructure to Logit.io Connectivity
 description: Learn how to check the connectivity from your infrastructure to your Logit.io stack and diagnose connectivity issues
 ---
 

--- a/src/pages/getting-started.mdx
+++ b/src/pages/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Started with Logit.io
-description: Learn how to create a new user account on the Logit.io platform
+description: Read Logit.io’s Getting Started article and learn how to create a new user account on the Logit.io platform
 breadcrumb: false
 pagination: false
 ---

--- a/src/pages/infrastructure-metrics/alerting/configure-cpu-alerts.mdx
+++ b/src/pages/infrastructure-metrics/alerting/configure-cpu-alerts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuring CPU Alerts
-description: Setup and configure CPU alerts to send notifications from Logit.io
+description: Follow the steps in our help article to setup and configure CPU alerts to send notifications from Logit.io
 ---
 
 # How to configure CPU alerts with Logit.io?

--- a/src/pages/infrastructure-metrics/alerting/configure-ram-alerts.mdx
+++ b/src/pages/infrastructure-metrics/alerting/configure-ram-alerts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuring RAM Usage Alerts
-description: Setup and configure RAM usage alerts to send notifications from Logit.io
+description: Follow the simple steps in our help article to setup and configure RAM usage alerts to send notifications from Logit.io
 ---
 
 # How to configure RAM usage alerts with Logit.io?

--- a/src/pages/infrastructure-metrics/getting-started.mdx
+++ b/src/pages/infrastructure-metrics/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get Started Sending Metrics
-description: Learn how to get started and explore Infrastructure Metrics with Grafana
+description: Read Logit.io’s in-depth help article to learn how to get started and explore Infrastructure Metrics with Grafana
 ---
 
 # Get Started Sending Metrics

--- a/src/pages/infrastructure-metrics/ingestion-pipeline/overview.mdx
+++ b/src/pages/infrastructure-metrics/ingestion-pipeline/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ingestion Pipeline
-description: Learn about Infrastructure Metrics Ingestion Pipeline in Logit.io
+description: An Infrastructure Metrics Ingestion Pipeline is a system designed to collect, process, and store metrics and performance data.
 ---
 
 # Infrastructure Metrics: Ingestion Pipeline

--- a/src/pages/infrastructure-metrics/ingestion-pipeline/remote-write.mdx
+++ b/src/pages/infrastructure-metrics/ingestion-pipeline/remote-write.mdx
@@ -1,6 +1,6 @@
 ---
 title: Remote Write
-description: Learn how to utilise and configure infrastructure Metrics Remote Write in Logit.io
+description: Remote write is a mechanism that sends metric data from one component to another. Learn how to use and configure Infrastructure Metrics Remote Write in Logit.io
 ---
 
 # Infrastructure Metrics: Remote Write

--- a/src/pages/infrastructure-metrics/statistics.mdx
+++ b/src/pages/infrastructure-metrics/statistics.mdx
@@ -1,6 +1,6 @@
 ---
 title: Statistics
-description: Learn how Infrastructure Metrics usage statistic is calculated in Logit.io
+description: Read our information help article to learn how Infrastructure Metrics usage statistic is calculated in Logit.io
 ---
 
 # Statistics

--- a/src/pages/infrastructure-metrics/visualizers/grafana.mdx
+++ b/src/pages/infrastructure-metrics/visualizers/grafana.mdx
@@ -1,5 +1,5 @@
 ---
-title: Using Grafana for Infrastructure Metrics Visualization
+title: View Infrastructure Metrics with Grafana
 description: Follow our getting started help article to learn how to use Grafana to effectively view your metrics in Logit.io.
 ---
 

--- a/src/pages/integrations/application-performance-monitoring/erlang/grpc.mdx
+++ b/src/pages/integrations/application-performance-monitoring/erlang/grpc.mdx
@@ -5,7 +5,7 @@ subTitle: Ship traces from Erlang to OpenSearch with OpenTelemetry (via gRPC)
 logo: erlang
 color: "#a31f34"
 stackTypes: apm
-description: Learn how to ship your Erlang program traces to OpenSearch with our example configurations.
+description: Use our example configuration to ship your Erlang program traces to OpenSearch. Send Erlang program traces to your Logit.io stacks.
 protocol: grpc
 ---
 

--- a/src/pages/integrations/application-performance-monitoring/go/grpc.mdx
+++ b/src/pages/integrations/application-performance-monitoring/go/grpc.mdx
@@ -5,7 +5,7 @@ subTitle: Ship traces from Go to OpenSearch with OpenTelemetry (via gRPC)
 logo: golang
 color: "#00b1d1"
 stackTypes: apm
-description: Learn how to ship your Go program traces to OpenSearch with our example configurations.
+description: Use our example configuration to ship your Go program traces to OpenSearch. Send Go program traces to your Logit.io stacks.
 protocol: grpc
 ---
 

--- a/src/pages/integrations/application-performance-monitoring/nodejs/grpc.mdx
+++ b/src/pages/integrations/application-performance-monitoring/nodejs/grpc.mdx
@@ -5,7 +5,7 @@ subTitle: Ship traces from Node.js to OpenSearch with OpenTelemetry (via gRPC)
 logo: nodejs
 color: "#82bb26"
 stackTypes: apm
-description: Learn how to ship your Node.js program traces to OpenSearch with our example configurations.
+description: Use our example configuration to ship your Node.js program traces to OpenSearch. Send Node.js program traces to your Logit.io stacks.
 protocol: grpc
 ---
 

--- a/src/pages/integrations/application-performance-monitoring/nodejs/https.mdx
+++ b/src/pages/integrations/application-performance-monitoring/nodejs/https.mdx
@@ -5,7 +5,7 @@ subTitle: Ship traces from Node.js to OpenSearch with OpenTelemetry (via HTTP/S)
 logo: nodejs
 color: "#82bb26"
 stackTypes: apm
-description: Learn how to ship your Node.js program traces to OpenSearch with our example configurations.
+description: Use our example configuration to learn how to ship your Node.js program traces to OpenSearch. Send your Node.js program traces to your Logit.io stacks.
 protocol: https
 protocolName: proto
 ---

--- a/src/pages/integrations/application-performance-monitoring/php/grpc.mdx
+++ b/src/pages/integrations/application-performance-monitoring/php/grpc.mdx
@@ -5,7 +5,7 @@ subTitle: Ship traces from PHP to OpenSearch with OpenTelemetry (via gRPC)
 logo: php
 color: "#777bb3"
 stackTypes: apm
-description: Learn how to ship your PHP program traces to OpenSearch with our example configurations.
+description: Use our example configuration to learn how to ship your PHP program traces to OpenSearch. Send your PHP program traces to your Logit.io stacks.
 protocol: grpc
 ---
 

--- a/src/pages/integrations/application-performance-monitoring/python/https.mdx
+++ b/src/pages/integrations/application-performance-monitoring/python/https.mdx
@@ -5,7 +5,7 @@ subTitle: Ship traces from Python to OpenSearch with OpenTelemetry (via HTTP/S)
 logo: python
 color: "#0e64a9"
 stackTypes: apm
-description: Learn how to ship your Python script traces to OpenSearch with our example configurations.
+description: Use our example configuration to ship your Python script traces to OpenSearch. Send Python script traces to your Logit.io stacks.
 protocol: https
 protocolName: http/protobuf
 ---

--- a/src/pages/integrations/application-performance-monitoring/ruby/https.mdx
+++ b/src/pages/integrations/application-performance-monitoring/ruby/https.mdx
@@ -5,7 +5,7 @@ subTitle: Ship traces from Ruby to OpenSearch with OpenTelemetry (via HTTP/S)
 logo: ruby
 color: "#ff0000"
 stackTypes: apm
-description: Learn how to ship your Ruby program traces to OpenSearch with our example configurations.
+description: Use our example configuration to learn how to ship your Ruby program traces to OpenSearch. Send Ruby program traces to your Logit.io stacks.
 protocol: https
 protocolName: http
 ---

--- a/src/pages/integrations/application-performance-monitoring/rust/https.mdx
+++ b/src/pages/integrations/application-performance-monitoring/rust/https.mdx
@@ -5,7 +5,7 @@ subTitle: Ship traces from Rust to OpenSearch with OpenTelemetry (via HTTP/S)
 logo: rust
 color: "#0f172a"
 stackTypes: apm
-description: Learn how to ship your Rust program traces to OpenSearch with our example configurations.
+description: Use our example configuration to ship your Rust program traces to OpenSearch. Send Rust program traces to your Logit.io stacks.
 protocol: https
 protocolName: http/protobuf
 ---

--- a/src/pages/integrations/application-performance-monitoring/swift/grpc.mdx
+++ b/src/pages/integrations/application-performance-monitoring/swift/grpc.mdx
@@ -5,7 +5,7 @@ subTitle: Ship traces from Swift to OpenSearch with OpenTelemetry (via gRPC)
 logo: swift
 color: "#ff9900"
 stackTypes: apm
-description: Learn how to ship your Swift program traces to OpenSearch with our example configurations.
+description: Use our example configuration to ship your Swift program traces to OpenSearch. Send your Swift program traces to your Logit.io stacks.
 protocol: grpc
 ---
 

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/certificate-authority-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/certificate-authority-telegraf-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-title: Google Certificate Authority Metrics via Telegraf
+title: Google Certificate Authority Metrics
 subTitle: Ship your Google Certificate Authority Metrics via Telegraf to your Logit.io Stack
 logo: googlecloud
 color: "#3c76d7"

--- a/src/pages/log-management/alerting/configuration/match-all-event-alerts.mdx
+++ b/src/pages/log-management/alerting/configuration/match-all-event-alerts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configure Alerts for OpenSearch to Match All/Any Events For a Specific Query
-description: How to create an any match alert for your OpenSearch logs or metrics
+description: Read Logit.io’s detailed help article to learn how to create any match alert for your OpenSearch logs or metrics
 ---
 
 # Configure Alerts for OpenSearch to match all/any events for a specific query

--- a/src/pages/log-management/alerting/configuration/percentage-match-alerts.mdx
+++ b/src/pages/log-management/alerting/configuration/percentage-match-alerts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configure Percentage Match Alerts for OpenSearch
-description: How to create a percentage match alert for your OpenSearch logs or metrics
+description: Follow the steps in Logit.io’s guide to learn how to create a percentage match alert for your OpenSearch logs or metrics
 ---
 
 # Configure Percentage Match Alerts for OpenSearch

--- a/src/pages/log-management/alerting/notifications/opsgenie.mdx
+++ b/src/pages/log-management/alerting/notifications/opsgenie.mdx
@@ -1,6 +1,6 @@
 ---
 title: How To Send Alerts from Logit.io to OpsGenie
-description: Learn how to setup and configure alerts and notifications from your Stacks to OpsGenie
+description: Follow the steps in Logit.io’s help article to setup and configure alerts and notifications from your Stacks to OpsGenie
 ---
 
 # How to send alerts from Logit.io to OpsGenie

--- a/src/pages/log-management/alerting/validating-alert-rules.mdx
+++ b/src/pages/log-management/alerting/validating-alert-rules.mdx
@@ -1,6 +1,6 @@
 ---
 title: How Do I Check My Elastalert Rule is Configured Correctly?
-description: Making sure that your Elastalert yaml file is formatted and configured correctly
+description: Follow the steps in Logit.io’s help article to guarante that your Elastalert yaml file is formatted and configured correctly
 ---
 
 # How can I check my Elastalert rule is configured correctly?

--- a/src/pages/log-management/faqs/how-to-integrate-with-okta.mdx
+++ b/src/pages/log-management/faqs/how-to-integrate-with-okta.mdx
@@ -1,6 +1,6 @@
 ---
 title: Set Up Integration With Okta
-description: How To Set up and configure Okta for Logit.io
+description: Integrating Okta with your Logit.io account streamlines user authentication and access control. Learn how to set up and configure Okta for Logit.io.
 ---
 
 # How To Set Up Integration With Okta

--- a/src/pages/log-management/faqs/how-to-send-azure-logs-and-metrics.mdx
+++ b/src/pages/log-management/faqs/how-to-send-azure-logs-and-metrics.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sending Azure Logs and Metrics to Logit.io
-description: Learn how to send Azure logs to Logit.io
+description: This article will break down the various Azure source integrations that you can implement in Logit.io. Learn how to send Azure logs to Logit.io
 ---
 
 # Sending Azure Logs to Logit.io

--- a/src/pages/log-management/grafana/viewing-logs.mdx
+++ b/src/pages/log-management/grafana/viewing-logs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Viewing Logs in Grafana
-description: Learn how to get started and explore your logs with Grafana
+description: Read logit.io’s detailed help article to learn how to get started and explore your logs in log management with Grafana
 ---
 
 # Viewing Logs in Grafana

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-amazon-s3-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-amazon-s3-input.mdx
@@ -1,6 +1,6 @@
 ---
 title: Add Amazon S3 Input
-description: Learn how to configure an Amazon S3 Input on your Logstash Instance
+description: Follow the simple steps outlined in Logit.io’s help article to learn how to configure an Amazon S3 Input on your Logstash Instance
 ---
 
 # How to add an Amazon S3 Input to your Log Stack

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-google-cloud-storage-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-google-cloud-storage-input.mdx
@@ -1,6 +1,6 @@
 ---
 title: Add Google Cloud Storage Input
-description: Learn how to configure a Google Cloud Storage Input on your Logstash Instance
+description: Follow Logit.io’s steps in this help article to learn how to configure a Google Cloud Storage Input on your Logstash Instance.
 ---
 
 # How to add a Google Cloud Storage Input to your Log Stack

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-syslog-ssl-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-syslog-ssl-input.mdx
@@ -1,6 +1,6 @@
 ---
 title: Add Syslog SSL Input
-description: Learn how to configure a Syslog SSL Input on your Logstash Instance
+description: Follow the simple steps in Logit.io’s help article to learn how to configure a Syslog SSL Input on your Logstash Instance
 ---
 
 # How to add a Syslog SSL Input to your Log Stack

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-tcp-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-tcp-input.mdx
@@ -1,6 +1,6 @@
 ---
 title: Add TCP Input
-description: Learn how to configure a Syslog TCP Input on your Logstash Instance
+description: Follow the simple steps in Logit.io’s help article to learn how to configure a Syslog TCP Input on your Logstash Instance
 ---
 
 # How to add a TCP Input to your Log Stack

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-tcp-ssl-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-tcp-ssl-input.mdx
@@ -1,6 +1,6 @@
 ---
 title: Add TCP SSL Input
-description: Learn how to add a TCP SSL Input to your Logstash Instance
+description: Follow the simple steps outlined in Logit.io’s help article to learn how to add a TCP SSL Input to your Logstash Instance
 ---
 
 # How to add a TCP SSL Input to your Log Stack

--- a/src/pages/log-management/kibana/cheatsheet.mdx
+++ b/src/pages/log-management/kibana/cheatsheet.mdx
@@ -1,6 +1,6 @@
 ---
 title: Logit.io Kibana Cheatsheet
-description: Useful cheatsheet to help with Kibana and Elastic Search Lucene query syntax
+description: Utilize Logit.io’s informative and detailed cheatsheet to help with Kibana and Elastic Search Lucene query syntax.
 ---
 
 # Logit.io Kibana ELK Cheatsheet

--- a/src/pages/log-management/kibana/enable-kibana-multi-stack.mdx
+++ b/src/pages/log-management/kibana/enable-kibana-multi-stack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Enabling Kibana Multi-Stack
-description: Learn how to enable and why you would use Kibana Multi-Stack
+description: Enabling Kibana multi-stack functionality allows you to manage and visualize data from multiple Elasticsearch clusters using a single Kibana instance.
 ---
 
 # How to enable Kibana Multi-Stack

--- a/src/pages/log-management/opensearch/index-management/aggregatable-text-fields.mdx
+++ b/src/pages/log-management/opensearch/index-management/aggregatable-text-fields.mdx
@@ -1,6 +1,6 @@
 ---
 title: Aggregatable Text Fields
-description: Learn how to change the status of a text field from non-aggregatable to aggregatable.
+description: An aggregatable text field means all values of documents for the text field are loaded into memory. Change the status of a text field to aggregatable.
 ---
 
 # Aggregatable text fields

--- a/src/pages/log-management/opensearch/index-management/changing-data-on-already-ingested-indexed-opensearch.mdx
+++ b/src/pages/log-management/opensearch/index-management/changing-data-on-already-ingested-indexed-opensearch.mdx
@@ -1,6 +1,6 @@
 ---
 title: Changing Field Datatypes
-description: I've sent some data to OpenSearch but need to change the datatype of a field
+description: Read Logit.io’s help article to learn how to change the datatype of a field for already indexed or sent data in OpenSearch
 ---
 
 # How do I change the datatype of a field for data already sent/indexed in OpenSearch?

--- a/src/pages/log-management/opensearch/index-management/listing-indexes.mdx
+++ b/src/pages/log-management/opensearch/index-management/listing-indexes.mdx
@@ -1,6 +1,6 @@
 ---
 title: List Indexes
-description: Learn how to list indexes in OpenSearch with Logit.io?
+description: Listing indexes in an OpenSearch cluster is simple and presents all available indexes and their status. Learn how to list indexes in OpenSearch with Logit.io.
 ---
 
 # How to list indexes in OpenSearch with Logit.io?

--- a/src/pages/log-management/opensearch/searching/querying-with-mapper-size.mdx
+++ b/src/pages/log-management/opensearch/searching/querying-with-mapper-size.mdx
@@ -1,6 +1,6 @@
 ---
 title: Querying With Mapper Size
-description: Discover how to query OpenSearch to find large log messages in this guide
+description: Read logit.io’s help article to learn how to enable the mapper-size plugin and discover how to query OpenSearch to find large log messages. 
 ---
 
 # How to query OpenSearch to find large log messages

--- a/src/pages/log-management/opensearch/searching/querying-with-python.mdx
+++ b/src/pages/log-management/opensearch/searching/querying-with-python.mdx
@@ -1,6 +1,6 @@
 ---
 title: Querying with Python
-description: Learn how to search OpenSearch with Python using Logit.io
+description: Learn how to craft efficient search queries in OpenSearch, utilizing Python to interact with the Logit.io API.
 ---
 
 # Querying OpenSearch with Python

--- a/src/pages/log-management/opensearch/timezones.mdx
+++ b/src/pages/log-management/opensearch/timezones.mdx
@@ -1,6 +1,6 @@
 ---
 title: Timezones
-description: Learn how to configure the timezone from the default OpenSearch UTC for timestamps
+description: OpenSearch uses the timezone of your browser by default, it is however possible to change this if you require. Learn how to change the timezone for timestamps.
 ---
 
 # How do timezones work in OpenSearch?

--- a/src/pages/log-management/security/authorizing-applications.mdx
+++ b/src/pages/log-management/security/authorizing-applications.mdx
@@ -1,6 +1,6 @@
 ---
 title: Authorizing Applications
-description: Learn how to secure and restrict which applications can ship logs to Logstash
+description: Read Logit.io’s help article to learn how to ensure that only authorized applications can send logs to Logstash
 ---
 
 # How to ensure that only authorised applications can send logs to Logstash

--- a/src/pages/log-management/security/ssl-certificate-expiry-notice.mdx
+++ b/src/pages/log-management/security/ssl-certificate-expiry-notice.mdx
@@ -1,6 +1,6 @@
 ---
 title: SSL Certification Expiry Notice
-description: Notification and guides associated with the rotation of Logstash SSL certificates
+description: Logit.io’s article outlines FAQs, notifications, and guides associated with the rotation of Logstash SSL certificates.
 ---
 
 # SSL Certificate Expiry Notice

--- a/src/pages/log-management/troubleshooting/how-can-i-monitor-my-stack.mdx
+++ b/src/pages/log-management/troubleshooting/how-can-i-monitor-my-stack.mdx
@@ -1,6 +1,6 @@
 ---
 title: How Can I Monitor My Stack Health
-description: Viewing the health and logs for my stacks and resolving common issues and problems
+description: Read Logit.io’s help article for viewing the health and logs for your stacks and resolving common issues and problems
 ---
 
 # How Can I Monitor My Logit.io Stack Health and Recover From Common Issues?

--- a/src/pages/log-management/troubleshooting/log-volume-count.mdx
+++ b/src/pages/log-management/troubleshooting/log-volume-count.mdx
@@ -1,6 +1,6 @@
 ---
 title: Log Volume Count
-description: Learn how to check your Log Management Log Volume count
+description: Read Logit.io’s detailed article to learn how to check your Log Management Log Volume count and other usage statistics.
 ---
 
 # Log Management: Log Volume Count

--- a/src/pages/opentelemetry/using-opentelemetry-for-metrics.mdx
+++ b/src/pages/opentelemetry/using-opentelemetry-for-metrics.mdx
@@ -1,6 +1,6 @@
 ---
 title: Using OpenTelemetry for Metrics
-description: How to Onboard and Get Started Sending Data using OpenTelemetry to your Metrics Stack
+description: This article walks you through onboarding and getting started sending data using OpenTelemetry to your Metrics Stack in Logit.io
 ---
 
 # Getting Started With OpenTelemetry for Metrics


### PR DESCRIPTION
All the meta descriptions that needed length increasing, shortened meta titles after the 'overusage email' commit.