### PR TITLE
Missing meta descriptions

### DIFF
--- a/src/pages/account-administration/account-access-users-teams/two-factor-authentication.mdx
+++ b/src/pages/account-administration/account-access-users-teams/two-factor-authentication.mdx
@@ -1,5 +1,6 @@
 ---
 title: Two Factor Authentication
+description: Read Logit.io's collection of two factor authentication articles to learn more about working with two factor authentication in Logit.io
 pagination: false
 timestamp: false
 ---

--- a/src/pages/account-administration/subscriptions-management-usage.mdx
+++ b/src/pages/account-administration/subscriptions-management-usage.mdx
@@ -1,5 +1,6 @@
 ---
 title: Subscriptions, Management & Usage
+description: Read Logit.io's collection of subscription, management & usage articles to learn more about managing and working with your Logit.io account.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/account-administration/subscriptions-management-usage/accounts.mdx
+++ b/src/pages/account-administration/subscriptions-management-usage/accounts.mdx
@@ -1,5 +1,6 @@
 ---
 title: Accounts
+description: Read Logit.io's collection of in-depth account articles to learn more about various aspects of your Logit.io account.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/account-administration/subscriptions-management-usage/product.mdx
+++ b/src/pages/account-administration/subscriptions-management-usage/product.mdx
@@ -1,5 +1,6 @@
 ---
 title: Product
+description: Read Logit.io's collection of in-depth product articles to learn more about various aspects of Logit.io's product.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/application-performance-monitoring/ingestion-pipeline.mdx
+++ b/src/pages/application-performance-monitoring/ingestion-pipeline.mdx
@@ -1,5 +1,6 @@
 ---
 title: Ingestion Pipeline
+description: Read Logit.io's collection of ingestion pipeline articles to learn more about various aspects of working with APM ingestion pipelines. 
 pagination: false
 timestamp: false
 ---

--- a/src/pages/application-performance-monitoring/jaeger.mdx
+++ b/src/pages/application-performance-monitoring/jaeger.mdx
@@ -1,5 +1,6 @@
 ---
 title: Jaeger
+description: Read Logit.io's collection of Jaeger articles to learn more about various aspects of working with hosted jaeger from Logit.io.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/infrastructure-metrics/alerting.mdx
+++ b/src/pages/infrastructure-metrics/alerting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Alerting
+description: Read Logit.io's collection of alerting articles to learn more about various aspects of infrastructure metrics alerting in Logit.io.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/infrastructure-metrics/ingestion-pipeline.mdx
+++ b/src/pages/infrastructure-metrics/ingestion-pipeline.mdx
@@ -1,5 +1,6 @@
 ---
 title: Ingestion Pipeline
+description: Read Logit.io's collection of ingestion pipeline articles to learn more about various aspects of working with infrastructure metrics ingestion pipelines.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/integrations.mdx
+++ b/src/pages/integrations.mdx
@@ -1,4 +1,5 @@
 ---
+description: Get started with Logit.io and follow the simple steps in our source integrations to begin shipping data to your Logit.io stacks.
 timestamp: false
 pagination: false
 breadcrumb: false

--- a/src/pages/integrations/application-performance-monitoring.mdx
+++ b/src/pages/integrations/application-performance-monitoring.mdx
@@ -1,5 +1,6 @@
 ---
 title: Application Performance Monitoring
+description: Follow the steps in Logit.io's apm integrations guides to begin shipping data from various sources to your Logit.io stacks.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/integrations/application-performance-monitoring/cpp.mdx
+++ b/src/pages/integrations/application-performance-monitoring/cpp.mdx
@@ -1,5 +1,6 @@
 ---
 title: C++
+description: Follow the steps in Logit.io's C++ source integrations to ship traces from C++ to OpenSearch with OpenTelemetry.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/integrations/application-performance-monitoring/erlang.mdx
+++ b/src/pages/integrations/application-performance-monitoring/erlang.mdx
@@ -1,5 +1,6 @@
 ---
 title: Erlang
+description: Follow the steps outlined in Logit.io's Erlang source integrations to ship traces from Erlang to OpenSearch with OpenTelemetry.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/integrations/application-performance-monitoring/net.mdx
+++ b/src/pages/integrations/application-performance-monitoring/net.mdx
@@ -1,5 +1,6 @@
 ---
 title: .Net
+description: Follow the steps outlined in Logit.io's .Net source integrations to ship traces from ASP.Net Core to OpenSearch with OpenTelemetry.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/integrations/application-performance-monitoring/nodejs.mdx
+++ b/src/pages/integrations/application-performance-monitoring/nodejs.mdx
@@ -1,5 +1,6 @@
 ---
 title: NodeJS
+description: Follow the steps outlined in Logit.io's Node.js source integrations to ship traces from Node.js to OpenSearch with OpenTelemetry.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/integrations/application-performance-monitoring/open-telemetry.mdx
+++ b/src/pages/integrations/application-performance-monitoring/open-telemetry.mdx
@@ -1,5 +1,6 @@
 ---
 title: OpenTelemetry
+description: Follow the steps in our source integration to learn how you can utilize the OpenTelemetry Collector to send traces to your Logit.io stacks.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/integrations/application-performance-monitoring/php.mdx
+++ b/src/pages/integrations/application-performance-monitoring/php.mdx
@@ -1,5 +1,6 @@
 ---
 title: PHP
+description: Follow the steps in Logit.io's PHP source integrations to ship traces from PHP to OpenSearch with OpenTelemetry.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/integrations/application-performance-monitoring/python.mdx
+++ b/src/pages/integrations/application-performance-monitoring/python.mdx
@@ -1,7 +1,8 @@
 ---
 title: Python
+description: Follow the simple steps in Logit.io's Python data integrations to start shipping traces from Python to OpenSearch with OpenTelemetry.
 pagination: false
 timestamp: false
 ---
 
-<FolderBrowser />
+<FolderBrowser />s

--- a/src/pages/integrations/application-performance-monitoring/python.mdx
+++ b/src/pages/integrations/application-performance-monitoring/python.mdx
@@ -5,4 +5,4 @@ pagination: false
 timestamp: false
 ---
 
-<FolderBrowser />s
+<FolderBrowser />

--- a/src/pages/integrations/infrastructure-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics.mdx
@@ -1,5 +1,6 @@
 ---
 title: Infrastructure Metrics
+description: Follow the steps outlined in Logit.io's infrastructure metrics source integrations to begin shipping metrics to Logit.io.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/integrations/infrastructure-metrics/applications.mdx
+++ b/src/pages/integrations/infrastructure-metrics/applications.mdx
@@ -1,5 +1,6 @@
 ---
 title: Applications
+description: Follow the steps in Logit.io's application source integrations to start shipping various metrics to your Logstash and Elasticsearch.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/integrations/infrastructure-metrics/google-cloud.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud.mdx
@@ -1,5 +1,6 @@
 ---
 title: Google Cloud
+description: Follow the steps in Logit.io's Google Cloud source integrations to ship metrics from Google Cloud to your Logit.io stacks.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/integrations/infrastructure-metrics/languages-and-libraries.mdx
+++ b/src/pages/integrations/infrastructure-metrics/languages-and-libraries.mdx
@@ -1,5 +1,6 @@
 ---
 title: Languages & Libraries
+description: Follow the steps outlined in Logit.io's Language & Library source integrations to send metrics to Logstash and Elasticsearch.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/integrations/infrastructure-metrics/open-telemetry.mdx
+++ b/src/pages/integrations/infrastructure-metrics/open-telemetry.mdx
@@ -1,5 +1,6 @@
 ---
 title: OpenTelemetry
+description: Follow the simple steps outlined in Logit.io's OpenTelemetry source integration to utilze the OpenTelemetry (OTEL) Collector for Metrics.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/integrations/infrastructure-metrics/protocols.mdx
+++ b/src/pages/integrations/infrastructure-metrics/protocols.mdx
@@ -1,5 +1,6 @@
 ---
 title: Protocols
+description: Follow the steps outlined in Logit.io's protocol source integrations to ship various metrics to Logstash and Elasticsearch.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/integrations/log-management.mdx
+++ b/src/pages/integrations/log-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: Log Management
+description: Follow the steps outlined in Logit.io's log management source integrations to begin shipping various logs to Logit.io.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/integrations/log-management/applications.mdx
+++ b/src/pages/integrations/log-management/applications.mdx
@@ -1,5 +1,6 @@
 ---
 title: Applications
+description: Follow the steps in Logit.io's application source integrations to ship logs from applications to Logstash.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/integrations/log-management/aws.mdx
+++ b/src/pages/integrations/log-management/aws.mdx
@@ -1,5 +1,6 @@
 ---
 title: Amazon Web Services (AWS)
+description: Follow the steps outlined in Logit.io's AWS source integrations to ship various logs from AWS to Logit.io.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/integrations/log-management/containerisation.mdx
+++ b/src/pages/integrations/log-management/containerisation.mdx
@@ -1,5 +1,6 @@
 ---
 title: Containerisation
+description: Follow the steps in Logit.io's containerization source integrations to start shipping various container logs to your hosted Logstash instance at Logit.io.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/integrations/log-management/data-types.mdx
+++ b/src/pages/integrations/log-management/data-types.mdx
@@ -1,6 +1,6 @@
 ---
 title: Data Types
-pagination: false
+description: Follow the steps outlined in Logit.io's data type source integrations to upload a file or JSON logs to Logstash.
 timestamp: false
 ---
 

--- a/src/pages/integrations/log-management/firewalls.mdx
+++ b/src/pages/integrations/log-management/firewalls.mdx
@@ -1,5 +1,6 @@
 ---
 title: Firewalls
+description: Follow the steps in Logit.io's firewall source integrations to ship logs from various firewalls to Logit.io.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/integrations/log-management/google-cloud.mdx
+++ b/src/pages/integrations/log-management/google-cloud.mdx
@@ -1,5 +1,6 @@
 ---
 title: Google Cloud
+description: Follow the steps in Logit.io's Google Cloud source integrations to ship logs from Google Cloud to Logstash.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/integrations/log-management/languages-and-libraries.mdx
+++ b/src/pages/integrations/log-management/languages-and-libraries.mdx
@@ -1,5 +1,6 @@
 ---
 title: Languages & Libraries
+description: Follow the steps outlined in Logit.io's Language & Library source integrations to send logs to Logstash and Elasticsearch.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/integrations/log-management/operating-systems.mdx
+++ b/src/pages/integrations/log-management/operating-systems.mdx
@@ -1,5 +1,6 @@
 ---
 title: Operating Systems
+description: Follow the simple steps in Logit.io's operating system data integrations to start shipping logs from various OS to Logstash.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/integrations/log-management/shippers.mdx
+++ b/src/pages/integrations/log-management/shippers.mdx
@@ -1,5 +1,6 @@
 ---
 title: Shippers
+description: Follow the steps in Logit.io's shippers integrations to learn how you can utilize various data shippers to send data to Logit.io
 pagination: false
 timestamp: false
 ---

--- a/src/pages/log-management/alerting/notifications.mdx
+++ b/src/pages/log-management/alerting/notifications.mdx
@@ -1,5 +1,6 @@
 ---
 title: Notifications
+description: Read Logit.io's collection of in-depth notification articles to learn more about various aspects of working with notifications in Logit.io.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/log-management/faqs.mdx
+++ b/src/pages/log-management/faqs.mdx
@@ -1,5 +1,6 @@
 ---
 title: F.A.Qs
+description: Read Logit.io's collection of F.A.Q articles to learn more about commonly asked questions relating to Logit.io's log management.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/log-management/ingestion-pipeline.mdx
+++ b/src/pages/log-management/ingestion-pipeline.mdx
@@ -1,5 +1,6 @@
 ---
 title: Ingestion Pipeline
+description: Read Logit.io's collection of ingestion pipeline articles to learn more about various aspects of working with log management ingestion pipelines.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/log-management/ingestion-pipeline/configuration.mdx
+++ b/src/pages/log-management/ingestion-pipeline/configuration.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configuration
+description: Read Logit.io's collection of ingestion pipeline related configuration articles to learn about aspects of log management ingestion pipeline configurations.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/log-management/kibana.mdx
+++ b/src/pages/log-management/kibana.mdx
@@ -1,5 +1,6 @@
 ---
 title: Kibana
+description: Read Logit.io's collection of in-depth Kibana articles to learn more about various aspects of working with Hosted Kibana from Logit.io.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/log-management/opensearch.mdx
+++ b/src/pages/log-management/opensearch.mdx
@@ -1,5 +1,6 @@
 ---
 title: OpenSearch
+description: Read Logit.io's collection of in-depth OpenSearch articles to learn more about various aspects of working with Hosted OpenSearch from Logit.io.
 pagination: false
 timestamp: false
 ---

--- a/src/pages/log-management/opensearch/index-management.mdx
+++ b/src/pages/log-management/opensearch/index-management.mdx
@@ -1,5 +1,6 @@
 ---
 title: Index Management
+description: Read Logit.io's collection of in-depth index management articles to learn more about various aspects of indexing with Logit.io
 pagination: false
 timestamp: false
 ---

--- a/src/pages/log-management/opensearch/index-management/mapping.mdx
+++ b/src/pages/log-management/opensearch/index-management/mapping.mdx
@@ -1,5 +1,6 @@
 ---
 title: Index Mappings
+description: Read Logit.io's collection of index mapping articles to learn more about various aspects of index mappings with Logit.io
 pagination: false
 timestamp: false
 ---

--- a/src/pages/log-management/opensearch/opensearch-dashboards.mdx
+++ b/src/pages/log-management/opensearch/opensearch-dashboards.mdx
@@ -1,5 +1,6 @@
 ---
 title: OpenSearch Dashboards
+description: Read Logit.io's collection of OpenSearch Dashboard articles to learn more about various aspects of working with Hosted OpenSearch Dashboards from Logit.io.
 pagination: false
 timestamp: false
 ---


### PR DESCRIPTION
the last of the missing meta descriptions. Mike told me to only change the JSON file for the homepage, and as there was only a JSON file for APM, log management, and infrastructure metrics (no frontmatter) I have left these for now. 