### PR TITLE
APM Integration Titles overwritten by automerge

### DIFF
--- a/src/pages/integrations/application-performance-monitoring/cpp.mdx
+++ b/src/pages/integrations/application-performance-monitoring/cpp.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenTelemetry C++
+title: C++
 pageTitle: OpenTelemetry C++ Configuration
 subTitle: Ship traces from C++ to OpenSearch with OpenTelemetry
 logo: cpp

--- a/src/pages/integrations/application-performance-monitoring/elixir.mdx
+++ b/src/pages/integrations/application-performance-monitoring/elixir.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenTelemetry Elixir
+title: Elixir
 pageTitle: OpenTelemetry Elixir Configuration
 subTitle: Ship traces from Elixir to OpenSearch with OpenTelemetry
 logo: elixir

--- a/src/pages/integrations/application-performance-monitoring/erlang.mdx
+++ b/src/pages/integrations/application-performance-monitoring/erlang.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenTelemetry Erlang
+title: Erlang
 pageTitle: OpenTelemetry Erlang Configuration
 subTitle: Ship traces from Erlang to OpenSearch with OpenTelemetry
 logo: erlang

--- a/src/pages/integrations/application-performance-monitoring/go.mdx
+++ b/src/pages/integrations/application-performance-monitoring/go.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenTelemetry Go
+title: Go
 pageTitle: OpenTelemetry Go Configuration
 subTitle: Ship traces from Go to OpenSearch with OpenTelemetry
 logo: golang

--- a/src/pages/integrations/application-performance-monitoring/java.mdx
+++ b/src/pages/integrations/application-performance-monitoring/java.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenTelemetry Java
+title: Java
 pageTitle: OpenTelemetry Java Configuration
 subTitle: Ship traces from Java to OpenSearch with OpenTelemetry
 logo: java

--- a/src/pages/integrations/application-performance-monitoring/net.mdx
+++ b/src/pages/integrations/application-performance-monitoring/net.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenTelemetry .NET Core
+title: .NET
 pageTitle: OpenTelemetry .NET Core Configuration
 subTitle: Ship traces from ASP.Net Core to OpenSearch with OpenTelemetry
 logo: aspnetcore

--- a/src/pages/integrations/application-performance-monitoring/nodejs.mdx
+++ b/src/pages/integrations/application-performance-monitoring/nodejs.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenTelemetry Node.js
+title: NodeJS
 pageTitle: OpenTelemetry Node.js Configuration
 subTitle: Ship traces from Node.js to OpenSearch with OpenTelemetry
 logo: nodejs

--- a/src/pages/integrations/application-performance-monitoring/open-telemetry.mdx
+++ b/src/pages/integrations/application-performance-monitoring/open-telemetry.mdx
@@ -1,5 +1,5 @@
 ---
-title: Traces OpenTelemetry Collector
+title: OpenTelemetry
 subTitle: OpenTelemetry (OTEL) Collector for Traces
 logo: opentelemetry
 color: "#2e62a4"

--- a/src/pages/integrations/application-performance-monitoring/php.mdx
+++ b/src/pages/integrations/application-performance-monitoring/php.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenTelemetry PHP
+title: PHP
 pageTitle: OpenTelemetry PHP Configuration
 subTitle: Ship traces from PHP to OpenSearch with OpenTelemetry
 logo: php

--- a/src/pages/integrations/application-performance-monitoring/python.mdx
+++ b/src/pages/integrations/application-performance-monitoring/python.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenTelemetry Python
+title: Python
 pageTitle: OpenTelemetry Python Configuration
 subTitle: Ship traces from Python to OpenSearch with OpenTelemetry
 logo: python

--- a/src/pages/integrations/application-performance-monitoring/ruby.mdx
+++ b/src/pages/integrations/application-performance-monitoring/ruby.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenTelemetry Ruby
+title: Ruby
 pageTitle: OpenTelemetry Ruby Configuration
 subTitle: Ship traces from Ruby to OpenSearch with OpenTelemetry
 logo: ruby

--- a/src/pages/integrations/application-performance-monitoring/rust.mdx
+++ b/src/pages/integrations/application-performance-monitoring/rust.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenTelemetry Rust
+title: Rust
 pageTitle: OpenTelemetry Rust Configuration
 subTitle: Ship traces from Rust to OpenSearch with OpenTelemetry
 logo: rust

--- a/src/pages/integrations/application-performance-monitoring/swift.mdx
+++ b/src/pages/integrations/application-performance-monitoring/swift.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenTelemetry Swift
+title: Swift
 pageTitle: OpenTelemetry Swift Configuration
 subTitle: Ship traces from Swift to OpenSearch with OpenTelemetry
 logo: swift


### PR DESCRIPTION
Titles were overwritten in automerge to previous text. This puts them back to what they should now be.