### PR TITLE
OpenTelemetry Ruby Config Typos

### DIFF
--- a/src/pages/integrations/application-performance-monitoring/ruby.mdx
+++ b/src/pages/integrations/application-performance-monitoring/ruby.mdx
@@ -35,7 +35,7 @@ total of three files in the `opentelemetry_example` folder.
 
 ### Configuring the App
 
-Open the `Gem` file and paste in the follow code, overwritting the existing content.
+Open the `Gem` file and paste in the following code, overwriting the existing content.
 
 ```json copy 
 # frozen_string_literal: true
@@ -129,7 +129,7 @@ endpoint that it is listening on.
 
 ![Ruby Endpoint](@/images/integrations/ruby/ruby-endpoint.png)
 
-Open a new Termal or Command Prompt window and make a curl request to the listening endpoint
+Open a new Terminal or Command Prompt window and make a curl request to the listening endpoint
 
 ```cmd copy
 curl http://127.0.0.1:4567


### PR DESCRIPTION
A few fixed typos from the Ruby configuration guide