### PR TITLE
Moved home page meta description

### DIFF
--- a/src/pages/_meta.json
+++ b/src/pages/_meta.json
@@ -1,7 +1,6 @@
 {
   "index": {
     "title": "Logit.io Documentation",
-    "description": "Logit.io is a powerful cost-effective observability platform. Follow our source integrations and help articles to utilize the platform efficiently",
     "theme": {
       "layout": "full",
       "sidebar": false,

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -1,3 +1,7 @@
+---
+description: Logit.io is a powerful cost-effective observability platform. Follow our source integrations and help articles to utilize the platform efficiently
+---
+
 ## Concepts & Features
 
 Here you can discover more about the available features to support your observability journey with Logit.io.


### PR DESCRIPTION
Moved the `description` meta property from `_meta.json` to the frontmatter, which works.

The description is now showing correctly in the HTML.

https://logitio.monday.com/boards/806674751/pulses/7304502227