### PR TITLE
Add tags to integrations

### DIFF
--- a/src/pages/integrations/application-performance-monitoring/cpp.mdx
+++ b/src/pages/integrations/application-performance-monitoring/cpp.mdx
@@ -6,6 +6,7 @@ logo: cpp
 color: "#1a3b63"
 description: Follow the steps in Logit.io's C++ source integrations to ship traces from C++ to OpenSearch with OpenTelemetry.
 stackTypes: apm
+tags: C++, Cpp, Cplusplus++, Apm, Grpc, Http
 ---
 
 Use OpenTelemetry to easily send C++ traces to your Logit.io Stack.

--- a/src/pages/integrations/application-performance-monitoring/elixir.mdx
+++ b/src/pages/integrations/application-performance-monitoring/elixir.mdx
@@ -6,6 +6,7 @@ logo: elixir
 color: "#800080"
 stackTypes: apm
 description: Follow the simple steps in our source integrations to ship traces from Elixir to OpenSearch with OpenTelemetry. Send Elixir data to your Logit.io stacks.
+tags: Elixir, Erlang, BEAM, Functional Programming, Apm, Grpc, Http
 ---
 
 Use OpenTelemetry to easily send Elixir traces to your Logit.io Stack.

--- a/src/pages/integrations/application-performance-monitoring/erlang.mdx
+++ b/src/pages/integrations/application-performance-monitoring/erlang.mdx
@@ -6,6 +6,7 @@ logo: erlang
 color: "#a31f34"
 stackTypes: apm
 description: Follow the steps outlined in Logit.io's Erlang source integrations to ship traces from Erlang to OpenSearch with OpenTelemetry.
+tags: Erlang, Elixir, BEAM, Functional Programming, Apm, Grpc, Http
 ---
 
 Use OpenTelemetry to easily send Erlang traces to your Logit.io Stack.

--- a/src/pages/integrations/application-performance-monitoring/go.mdx
+++ b/src/pages/integrations/application-performance-monitoring/go.mdx
@@ -6,6 +6,7 @@ logo: golang
 color: "#00b1d1"
 stackTypes: apm
 description: Follow our source integrations to send traces from Go to OpenSearch with OpenTelemetry. Ship Go data to your Logit.io stacks.
+tags: Go, Golang, Apm, Grpc, Http
 ---
 
 Use OpenTelemetry to easily send Go traces to your Logit.io Stack.

--- a/src/pages/integrations/application-performance-monitoring/java.mdx
+++ b/src/pages/integrations/application-performance-monitoring/java.mdx
@@ -6,6 +6,7 @@ logo: java
 color: "#f39100"
 stackTypes: apm
 description: Follow Logit.io's source integrations to begin shipping traces from Java to OpenSearch with OpenTelemetry.
+tags: Java, JVM, Apm, Grpc, Http
 ---
 
 Use OpenTelemetry to easily send Java traces to your Logit.io Stack.

--- a/src/pages/integrations/application-performance-monitoring/net.mdx
+++ b/src/pages/integrations/application-performance-monitoring/net.mdx
@@ -6,6 +6,7 @@ logo: aspnetcore
 color: "#465aaa"
 stackTypes: apm
 description: Follow the steps outlined in Logit.io's .Net source integrations to ship traces from ASP.Net Core to OpenSearch with OpenTelemetry.
+tags: APM, Dotnet, .NET, Microsoft, Core, Dotnet Core, ASP, Application Performance Monitoring, Apm, Dotnetcore, Grpc, Https
 ---
 
 Use OpenTelemetry to easily send .NET Core traces to your Logit.io Stack.

--- a/src/pages/integrations/application-performance-monitoring/nodejs.mdx
+++ b/src/pages/integrations/application-performance-monitoring/nodejs.mdx
@@ -6,6 +6,7 @@ logo: nodejs
 color: "#82bb26"
 stackTypes: apm
 description: Follow the steps outlined in Logit.io's Node.js source integrations to ship traces from Node.js to OpenSearch with OpenTelemetry.
+tags: NodeJS, JavaScript, Apm, Nodejs, Grpc, Http
 ---
 
 Use OpenTelemetry to easily send Node.js traces to your Logit.io stack.

--- a/src/pages/integrations/application-performance-monitoring/open-telemetry.mdx
+++ b/src/pages/integrations/application-performance-monitoring/open-telemetry.mdx
@@ -6,6 +6,7 @@ color: "#2e62a4"
 description: Follow the steps in our source integration to learn how you can utilize the OpenTelemetry Collector to send traces to your Logit.io stacks.
 stackTypes: apm
 sslPortType: beats-ssl
+tags: OTEL, OTEL Collector, OpenTelemetry, Logs, Metrics, Traces, Telemetry
 ---
 
 The OpenTelemetry Collector allows you to send traces to your Logit.io stacks.

--- a/src/pages/integrations/application-performance-monitoring/php.mdx
+++ b/src/pages/integrations/application-performance-monitoring/php.mdx
@@ -6,6 +6,7 @@ logo: php
 color: "#777bb3"
 stackTypes: apm
 description: Follow the steps in Logit.io's PHP source integrations to ship traces from PHP to OpenSearch with OpenTelemetry.
+tags: PHP, Hypertext Preprocessor, Apm, Php, Grpc, Http
 ---
 
 Use OpenTelemetry to easily send PHP traces to your Logit.io Stack.

--- a/src/pages/integrations/application-performance-monitoring/python.mdx
+++ b/src/pages/integrations/application-performance-monitoring/python.mdx
@@ -6,6 +6,7 @@ logo: python
 color: "#0e64a9"
 stackTypes: apm
 description: Follow the simple steps in Logit.io's Python data integrations to start shipping traces from Python to OpenSearch with OpenTelemetry.
+tags: Python, Flask, Django, Web Framework, Apm, Grpc, Https
 ---
 
 Use OpenTelemetry to easily send Python traces to your Logit.io Stack.

--- a/src/pages/integrations/application-performance-monitoring/ruby.mdx
+++ b/src/pages/integrations/application-performance-monitoring/ruby.mdx
@@ -6,6 +6,7 @@ logo: ruby
 color: "#ff0000"
 stackTypes: apm
 description: Logit.io documentation for Ruby source integrations. Follow our guides to send Ruby data to Logit.io.
+tags: Ruby, Ruby on Rails, Web Framework, Apm, Grpc, Http
 ---
 
 Use OpenTelemetry to easily send Ruby traces to your Logit.io Stack.

--- a/src/pages/integrations/application-performance-monitoring/rust.mdx
+++ b/src/pages/integrations/application-performance-monitoring/rust.mdx
@@ -6,6 +6,7 @@ logo: rust
 color: "#0f172a"
 stackTypes: apm
 description: Read Logit.io's numerous Rust APM source integrations from Logit.io documentation to learn how to send Rust data to Logit.io
+tags: Rust, Systems Programming, Programming Language, Apm, Grpc, Http
 ---
 
 Use OpenTelemetry to easily send Rust traces to your Logit.io Stack.

--- a/src/pages/integrations/application-performance-monitoring/swift.mdx
+++ b/src/pages/integrations/application-performance-monitoring/swift.mdx
@@ -5,7 +5,8 @@ subTitle: Ship traces from Swift to OpenSearch with OpenTelemetry
 logo: swift
 color: "#ff9900"
 stackTypes: apm
-description: Learn how to send Swift data to your Logit.io stacks with this collection of Swift APM source integrations 
+description: Learn how to send Swift data to your Logit.io stacks with this collection of Swift APM source integrations
+tags: Swift, iOS, macOS, WatchOS, tvOS, Apple, Apm, Grpc, Http
 ---
 
 Use OpenTelemetry to easily send Swift traces to your Logit.io Stack.

--- a/src/pages/integrations/infrastructure-metrics/applications/mongodb-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/applications/mongodb-metrics.mdx
@@ -6,6 +6,7 @@ color: "#419544"
 description: How to send MongoDB server metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send MongoDB database server metrics to Logstash. 
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Metrics, Metricbeat, Stats, Database, MongoDB, NoSQL, Module, Mongodb
 ---
 
 Metricbeat is a lightweight shipper that helps you monitor your MongoDB servers by collecting metrics running on the MongoDB server. 

--- a/src/pages/integrations/infrastructure-metrics/applications/mysql-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/applications/mysql-metrics.mdx
@@ -6,6 +6,7 @@ color: "#00758f"
 description: How to send MySql database server metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send MySql server metrics to Logstash or Elasticsearch. 
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Metrics, Metricbeat, Stats, MySQL, Database, Module, Mysql
 ---
 
 Metricbeat is a lightweight shipper that helps you monitor your MySql database servers by collecting metrics running on the MySql server. 

--- a/src/pages/integrations/infrastructure-metrics/applications/postgresql-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/applications/postgresql-metrics.mdx
@@ -6,6 +6,7 @@ color: "#336791"
 description: How to send PostgreSQL database server metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send PostgreSQL server metrics to Logstash.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Database, DB, PostgreSQL, RDBMS, Metricset, Module, Postgresql
 ---
 
 Metricbeat is a lightweight shipper that helps you monitor 

--- a/src/pages/integrations/infrastructure-metrics/applications/puppet.mdx
+++ b/src/pages/integrations/infrastructure-metrics/applications/puppet.mdx
@@ -6,6 +6,7 @@ color: "#ffb600"
 description: Puppet Server example configuration to send your Puppet server metrics to your Hosted ELK Logstash instance.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Beats, Logs, Metrics, Metricbeat, Puppet, Jolokia, Configuration Management, IT Automation, Server
 ---
 
 Metricbeat is a lightweight shipper that helps you monitor Puppet 

--- a/src/pages/integrations/infrastructure-metrics/aws/aws-eks-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/aws/aws-eks-metrics.mdx
@@ -5,6 +5,7 @@ logo: aws
 color: "#ff9900"
 stackTypes: metrics
 description: Send AWS-EKS Metrics to VictoriaMetrics using the VMAgent instructions below and begin analysing your data
+tags: Metrics, VictoriaMetrics, Prometheus, VMagent, AWS, EKS, Kubernetes, Cloud Metrics, Aws Eks Metrics
 ---
 
 VMAgent is a tiny but mighty agent which helps you collect 

--- a/src/pages/integrations/infrastructure-metrics/aws/aws-eks.mdx
+++ b/src/pages/integrations/infrastructure-metrics/aws/aws-eks.mdx
@@ -6,6 +6,7 @@ color: "#ff9900"
 stackTypes: metrics
 description: Send your AWS EKS metrics to logit.io via logstash using the instructions below and begin searching your data
 sslPortType: beats-ssl
+tags: Metrics, Amazon, AWS, EKS, Container, Kubernetes, Cloud Metrics, Aws Eks
 ---
 
 Metricbeat is an open source shipping agent that lets you ship AWS Elastic 

--- a/src/pages/integrations/infrastructure-metrics/aws/cloudwatch.mdx
+++ b/src/pages/integrations/infrastructure-metrics/aws/cloudwatch.mdx
@@ -5,6 +5,7 @@ logo: aws_cloudwatch
 color: "#759c3e"
 stackTypes: metrics
 description: Use Logit.io's Amazon CloudWatch example configuration to easily forward and send your metrics to Logstash and Elasticsearch.
+tags: Metrics, AWS, Amazon, CloudWatch, EC2, Cloud Logs, Cloudwatch
 ---
 
 <Steps>

--- a/src/pages/integrations/infrastructure-metrics/aws/ec2.mdx
+++ b/src/pages/integrations/infrastructure-metrics/aws/ec2.mdx
@@ -5,6 +5,7 @@ logo: aws
 color: "#ff9900"
 stackTypes: metrics
 description: Use Logit.io's Amazon EC2 logging example configuration to easily forward and send your metrics to Logstash and Elasticsearch.
+tags: Metrics, AWS, Amazon, CloudWatch, EC2, Cloud Metrics, Ec2
 ---
 
 <Steps>

--- a/src/pages/integrations/infrastructure-metrics/aws/telegraf-aws-ecs.mdx
+++ b/src/pages/integrations/infrastructure-metrics/aws/telegraf-aws-ecs.mdx
@@ -6,6 +6,7 @@ color: "#ff9900"
 stackTypes: metrics
 description: Use our example to configure Telegraf to ship AWS ECS metrics to your Logit.io stacks. Configure Telegraf to send ECS metrics to Prometheus.
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, AWS, ECS, Fargate, Prometheus, Cloud Computing, Api
 ---
 
 <Steps>

--- a/src/pages/integrations/infrastructure-metrics/azure/azure-container-activity-logs.mdx
+++ b/src/pages/integrations/infrastructure-metrics/azure/azure-container-activity-logs.mdx
@@ -5,6 +5,7 @@ logo: azure
 color: "#0089d6"
 description: Ship your Azure container activity logs to Logit.io via Logstash using the instructions below and start analysing your data
 stackTypes: metrics
+tags: Microsoft, Azure, Event Hub, Azure Metrics, Azure Monitoring, Azure Diagnostics, Azure Monitor, Azure Container, Azure Activity Logs, Cloud Metrics
 ---
 
 Learn how to ship Azure Container activity logs into the Logit.io ELK Stack via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/azure/azure-kubernetes.mdx
+++ b/src/pages/integrations/infrastructure-metrics/azure/azure-kubernetes.mdx
@@ -6,6 +6,7 @@ color: "#834c9a"
 description: How to send Azure Kubernetes metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send Azure Kubernetes metrics to Logstash or Elasticsearch.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Metrics, Metricbeat, Stats, Kubernetes, K8s, Container Orchestration, Module
 ---
 
 Metricbeat is a lightweight shipper that helps you monitor Azure Kubernetes Service by 

--- a/src/pages/integrations/infrastructure-metrics/azure/azure-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/azure/azure-metrics.mdx
@@ -6,6 +6,7 @@ color: "#0089d6"
 description: Send your Azure platform Metrics to logit.io via logstash using the instructions below and begin searching your data
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: microsoft, azure, event hub, Azure Metrics, Azure Monitoring, Azure Diagnostics, Azure Insights, Azure Management, Azure Integration
 ---
 
 Stream Azure monitoring metrics to an event hub and configure Logstash to pull the metrics into the Logit.io stack.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/ai-platform-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/ai-platform-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: googleai
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google AI Platform metrics to Logit.io. Configure Telegraf to send Google AI Platform metrics to ELK.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google AI Platform, Prometheus, Artificial Intelligence, Ai
 ---
 
 Configure Telegraf to ship Google AI Platform metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/api-gateway-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/api-gateway-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudApis
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google API Gateway metrics to Logit.io. Configure Telegraf to send Google API Gateway metrics to ELK.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google API Gateway, Prometheus, Cloud Computing, Api
 ---
 
 Configure Telegraf to ship Google API Gateway metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/api-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/api-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google Cloud API metrics to Logit.io. Configure Telegraf to send Google Cloud API metrics to Logstash or Elastic.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Cloud API, API Management, Cloud Computing, Api
 ---
 
 Configure Telegraf to ship Google Cloud API metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/apigee-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/apigee-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google Apigee metrics to Logit.io. Configure Telegraf to send Google Apigee metrics to Logstash or Elastic.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Apigee, API Management, API Gateway
 ---
 
 Configure Telegraf to ship Google Apigee metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/app-engine-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/app-engine-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ color: "#3c76d7"
 logo: googlecloud
 description: Use our example to configure Telegraf to ship Google App Engine metrics to your Logit.io stacks. Configure Telegraf to send Google App Engine metrics to ELK.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google App Engine, Platform as a Service, PaaS
 ---
 
 Configure Telegraf to ship Google App Engine metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/armor-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/armor-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudArmor
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google Cloud Armour metrics to Logit.io. Configure Telegraf to send Google Cloud Armour metrics to ELK.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Cloud Armour, Security, DDoS Protection
 ---
 
 Configure Telegraf to ship Google Cloud Armour metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/assistant-smart-home-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/assistant-smart-home-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#3c76d7"
 description: Configure Telegraf to ship Google Assistant Smart Home metrics to Logit.io. Get started using our Telegraf Google Assistant Smart Home metrics configuration.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Assistant Smart Home, IoT, Internet of Things
 ---
 
 Configure Telegraf to ship Google Assistant Smart Home metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/bi-engine-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/bi-engine-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#3c76d7"
 description: Configure Telegraf to ship Google BigQuery BI Engine metrics to your Logit.io stacks. Use our Telegraf Google BigQuery BI Engine metrics example configuration.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google BigQuery BI Engine, Business Intelligence, Data Analytics, Bi
 ---
 
 Configure Telegraf to ship Google BigQuery BI Engine metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/big-query-data-transfer-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/big-query-data-transfer-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleBigquery
 color: "#3c76d7"
 description: Configure Telegraf to ship Google BigQuery BI Engine metrics to your Logit.io stacks. Use our Telegraf Google BigQuery BI Engine metrics example configuration.
 stackTypes: metrics
+tags: Telegraf, metrics, telemetry, opentelemetry, instrumentation, Google BigQuery Data Transfer, Big, Query
 ---
 
 Configure Telegraf to ship Google BigQuery Data Transfer metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/big-query-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/big-query-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleBigquery
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google BigQuery metrics to Logit.io. Configure Telegraf to send Google BigQuery metrics to Logstash or Elastic.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google BigQuery, Data Warehouse, SQL, Big, Query
 ---
 
 Configure Telegraf to ship Google BigQuery metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/big-table-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/big-table-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudBigtable
 color: "#3c76d7"
 description: Configure Telegraf to ship Google Cloud BigTable metrics to Logit.io. Get started using our Telegraf Google Cloud BigTable metrics example configuration.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Cloud BigTable, NoSQL, Database, Bigtable
 ---
 
 Configure Telegraf to ship Google Cloud BigTable metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/certificate-authority-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/certificate-authority-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#3c76d7"
 description: Configure Telegraf to ship Google Certificate Authority metrics to Logit.io. Get started using our Telegraf Google Certificate Authority metrics example.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Certificate Authority, Security, Public Key Infrastructure
 ---
 
 Configure Telegraf to ship Google Certificate Authority metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/composer-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/composer-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudComposer
 color: "#3c76d7"
 description: Configure Telegraf to ship Google Cloud Composer metrics to Logit.io. Get started using our Telegraf Google Cloud Composer metrics example configuration.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Cloud Composer, Workflow Orchestration, Cloud Computing
 ---
 
 Configure Telegraf to ship Google Cloud Composer metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/compute-engine-autoscaler-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/compute-engine-autoscaler-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleComputeEngine
 color: "#3c76d7"
 description: Configure Telegraf to ship Google Compute Engine metrics to your Logit.io stacks. Get started using our Telegraf Google Compute Engine metrics example.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Compute Engine Autoscaler, Autoscaling
 ---
 
 Configure Telegraf to ship Google Compute Engine Autoscaler metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/compute-engine-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/compute-engine-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleComputeEngine
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google Compute Engine metrics to Logit.io. Configure Telegraf to send Google Compute Engine metrics to ELK.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Compute Engine, Virtual Machine, VM
 ---
 
 Configure Telegraf to ship Google Compute Engine metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/contact-center-ai-insights-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/contact-center-ai-insights-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#3c76d7"
 description: Set up Telegraf to ship Google Contact Center AI Insights metrics to Logit.io. Use our Telegraf Google Contact Center AI Insights metrics example configuration.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Contact Center AI Insights, Customer Service Insights, Ai
 ---
 
 Configure Telegraf to ship Google Contact Center AI Insights metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/data-loss-prevention-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/data-loss-prevention-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#3c76d7"
 description: Configure Telegraf to ship Google Cloud Data Loss Prevention metrics to Logit.io. Use our Telegraf Google Cloud Data Loss Prevention metrics configuration.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Cloud Data Loss Prevention, Security, Data Protection
 ---
 
 Configure Telegraf to ship Google Cloud Data Loss Prevention metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/dataflow-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/dataflow-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleDataflow
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google Dataflow metrics to Logit.io. Configure Telegraf to send Google Dataflow metrics to Logstash or Elastic.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Dataflow, Data Processing, Stream Processing
 ---
 
 Configure Telegraf to ship Google Dataflow metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/dataproc-metastore-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/dataproc-metastore-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleDataproc
 color: "#3c76d7"
 description: Configure Telegraf to ship Google Dataproc Metastore metrics to your Logit.io stacks. Get started using our Telegraf Google Dataproc Metastore metrics example.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Dataproc Metastore, Data Management
 ---
 
 Configure Telegraf to ship Google Dataproc Metastore metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/dataproc-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/dataproc-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleDataproc
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google Dataproc metrics to Logit.io. Configure Telegraf to send Google Dataproc metrics to Logstash or Elastic.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Dataproc, Data Processing, Cluster Management
 ---
 
 Configure Telegraf to ship Google Dataproc metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/datastore-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/datastore-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudDatastore
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google Datastore metrics to Logit.io. Configure Telegraf to send Google Datastore metrics to Logstash or Elastic.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Datastore, NoSQL, Database
 ---
 
 Configure Telegraf to ship Google Datastore metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/datastream-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/datastream-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google Datastream metrics to Logit.io. Configure Telegraf to send Google Datastream metrics to ELK.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Datastream, Data Integration, Real-time Data
 ---
 
 Configure Telegraf to ship Google Datastream metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/dns-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/dns-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google Cloud DNS metrics to Logit.io. Configure Telegraf to send Google Cloud DNS metrics to Logstash or Elastic.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Cloud DNS, Domain Name System, Dns
 ---
 
 Configure Telegraf to ship Google Cloud DNS metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/filestore-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/filestore-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudFilestore
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google Filestore metrics to Logit.io. Configure Telegraf to send Google Filestore metrics to Logstash or Elastic.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Filestore, File Storage, Cloud File Storage
 ---
 
 Configure Telegraf to ship Google Filestore metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/firebase-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/firebase-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google Firebase metrics to Logit.io. Configure Telegraf to send Google Firebase metrics to Logstash or Elastic.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Firebase, Mobile App Development, Real-time Database
 ---
 
 Configure Telegraf to ship Google Firebase metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/firestore-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/firestore-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google Firestore metrics to Logit.io. Configure Telegraf to send Google Firestore metrics to Logstash or Elastic.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Firestore, Cloud Database, NoSQL
 ---
 
 Configure Telegraf to ship Google Firestore metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/firewall-insights-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/firewall-insights-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudFirewallRules
 color: "#3c76d7"
 description: Configure Telegraf to ship Google Firewall Insights metrics to Logit.io. Get started using our Telegraf Google Firewall Insights metrics example configuration.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Firewall Insights, Network Security, Firewall Analytics
 ---
 
 Configure Telegraf to ship Google Firewall Insights metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/functions-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/functions-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#3c76d7"
 description: Configure Telegraf to ship Google Cloud Functions metrics to Logit.io. Get started using our Telegraf Google Cloud Functions metrics example configuration.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Cloud Functions, Serverless Computing
 ---
 
 Configure Telegraf to ship Google Cloud Functions metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/gke-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/gke-metrics.mdx
@@ -6,6 +6,7 @@ color: "#3a64ad"
 description: Send your Google Kubernetes Engine metrics to logit.io via logstash using the instructions below and begin searching your data
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Metrics, Google, GKE, Container, Kubernetes, Google Kubernetes Engine, Google Cloud, Cloud Metrics, Gke
 ---
 
 Metricbeat is an open source shipping agent that lets you ship Google 

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/healthcare-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/healthcare-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#3c76d7"
 description: Configure Telegraf to ship Google Cloud Healthcare metrics to Logit.io. Get started using our Telegraf Google Cloud Healthcare metrics example configuration.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Cloud Healthcare, Health API, Api
 ---
 
 Configure Telegraf to ship Google Cloud Healthcare metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/identity-access-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/identity-access-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#3c76d7"
 description: Configure Telegraf to ship Google Identity Access metrics to Logit.io. Get started using our Telegraf Google Identity Access metrics example configuration.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Identity Access, Security Metrics, Access Management
 ---
 
 Configure Telegraf to ship Google Identity Access metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/ids-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/ids-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google Cloud IDS metrics to Logit.io. Configure Telegraf to send Google Cloud IDS metrics to Logstash or Elastic.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Cloud IDS, Intrusion Detection System, Ids
 ---
 
 Configure Telegraf to ship Google Cloud IDS metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/interconnect-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/interconnect-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudInterconnect
 color: "#3c76d7"
 description: Configure Telegraf to ship Google Cloud Interconnect metrics to your Logit.io stacks. Get started using our Telegraf Google Cloud Interconnect metrics example.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Cloud Interconnect, Networking, Network
 ---
 
 Configure Telegraf to ship Google Cloud Interconnect metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/iot-core-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/iot-core-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudIotCore
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google IOT Core metrics to Logit.io. Configure Telegraf to send Google IOT Core metrics to Logstash or Elastic.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google IOT Core, Internet of Things, IoT, Iot
 ---
 
 Configure Telegraf to ship Google IOT Core metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/kubernetes-engine-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/kubernetes-engine-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudFirewallRules
 color: "#3c76d7"
 description: Configure Telegraf to ship Google Kubernetes Engine metrics to your Logit.io stacks. Get started using our Telegraf Google Kubernetes Engine metrics example.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Kubernetes Engine, Container Orchestration
 ---
 
 Configure Telegraf to ship Google Kubernetes Engine metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/kubernetes-engine.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/kubernetes-engine.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#3a64ad"
 description: Send GCloud GKE Metrics to VictoriaMetrics using the vmagent instructions below and begin analysing your data
 stackTypes: metrics
+tags: Metrics, VictoriaMetrics, Prometheus, VMagent, Time Series Database, Google Cloud, GKE, GCloud, Kubernetes, Cloud Metrics, Google Gke Metrics
 ---
 
 Vmagent is a tiny but mighty agent which helps you collect metrics from various sources and store them in VictoriaMetrics.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/load-balancing-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/load-balancing-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudLoadBalancing
 color: "#3c76d7"
 description: Configure Telegraf to ship Google Cloud Load Balancing metrics to Logit.io. Use our Telegraf Google Cloud Load Balancing metrics example configuration.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Cloud Load Balancing, Traffic Balancing, Load Balancer
 ---
 
 Configure Telegraf to ship Google Cloud Load Balancing metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/logging-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/logging-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudLogging
 color: "#3c76d7"
 description: Configure Telegraf to ship Google Cloud Logging metrics to Logit.io. Get started using our Telegraf Google Cloud Logging metrics example configuration.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Cloud Logging, Log Management, Logs
 ---
 
 Configure Telegraf to ship Google Cloud Logging metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/managed-service-active-directory-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/managed-service-active-directory-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudFirewallRules
 color: "#3c76d7"
 description: Set up Telegraf to ship Google Managed Service Active Directory metrics to Logit.io. Use our Telegraf Google Managed Service Active Directory metrics example.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Managed Service Active Directory, Directory Services, Ad
 ---
 
 Configure Telegraf to ship Google Managed Service Active Directory metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/memory-store-memcached-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/memory-store-memcached-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudMemorystore
 color: "#3c76d7"
 description: Configure Telegraf to ship Google Memory Store Memcached metrics to Logit.io. Use our Telegraf Google Memory Store Memcached metrics example configuration.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Memory Store Memcached, In-memory Data Store
 ---
 
 Configure Telegraf to ship Google Memory Store Memcached metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/memory-store-redis-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/memory-store-redis-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudMemorystore
 color: "#3c76d7"
 description: Configure Telegraf to ship Google Memory Store Redis metrics to Logit.io. Use our Telegraf Google Memory Store Redis metrics example configuration.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Memory Store Redis, In-memory Data Store
 ---
 
 Configure Telegraf to ship Google Memory Store Redis metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/monitoring-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/monitoring-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudMonitoring
 color: "#3c76d7"
 description: Configure Telegraf to ship Google Cloud Monitoring metrics to your Logit.io stacks. Get started using our Telegraf Google Cloud Monitoring metrics example.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Cloud Monitoring, Performance Monitoring
 ---
 
 Configure Telegraf to ship Google Cloud Monitoring metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/network-topology-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/network-topology-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudNetwork
 color: "#3c76d7"
 description: Configure Telegraf to ship Google Network Topology metrics to Logit.io. Get started using our Telegraf Google Network Topology metrics example configuration.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Network Topology, Cloud Networking
 ---
 
 Configure Telegraf to ship Google Network Topology metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/postgresql-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/postgresql-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudSql
 color: "#3c76d7"
 description: Configure Telegraf to ship Google Cloud PostgreSQL metrics to Logit.io. Get started using our Telegraf Google Cloud PostgreSQL metrics example configuration.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Cloud PostgreSQL, Database, SQL, Postgresql
 ---
 
 Configure Telegraf to ship Google Cloud PostgreSQL metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/pubsub-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/pubsub-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GooglePubSub
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google Pub Sub metrics to Logit.io. Configure Telegraf to send Google Pub Sub metrics to Logstash or Elastic.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Pub Sub, Messaging, Event Streaming
 ---
 
 Configure Telegraf to ship Google Pub Sub metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/recaptcha-enterprise-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/recaptcha-enterprise-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#3c76d7"
 description: Configure Telegraf to ship Google Recaptcha Enterprise metrics to your Logit.io stacks. Use our Telegraf Google Recaptcha Enterprise metrics configuration.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Recaptcha Enterprise, Security, CAPTCHA
 ---
 
 Configure Telegraf to ship Google Recaptcha Enterprise metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/recommendations-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/recommendations-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#3c76d7"
 description: Configure Telegraf to ship Google Recommendations metrics to your Logit.io stacks. Get started using our Telegraf Google Recommendations metrics configuration.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Recommendations, Machine Learning, AI
 ---
 
 Configure Telegraf to ship Google Recommendations metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/router-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/router-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudRouter
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google Cloud Router metrics to Logit.io. Configure Telegraf to send Google Cloud Router metrics to ELK.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Cloud Router, Networking, Network
 ---
 
 Configure Telegraf to ship Google Cloud Router metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/run-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/run-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudRun
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google Cloud Run metrics to Logit.io. Configure Telegraf to send Google Cloud Run metrics to Logstash or Elastic.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Cloud Run, Containerization, Containers
 ---
 
 Configure Telegraf to ship Google Cloud Run metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/sql-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/sql-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudSql
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google Cloud SQL metrics to Logit.io. Configure Telegraf to send Google Cloud SQL metrics to Logstash or Elastic.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Cloud SQL, Database, Sql
 ---
 
 Configure Telegraf to ship Google Cloud SQL metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/storage-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/storage-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudStorage
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google Cloud Storage metrics to Logit.io. Configure Telegraf to send Google Cloud Storage metrics to ELK.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Cloud Storage, Object Storage
 ---
 
 Configure Telegraf to ship Google Cloud Storage metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/storage-transfer-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/storage-transfer-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudStorage
 color: "#3c76d7"
 description: Configure Telegraf to ship Google Storage Transfer metrics to Logit.io. Get started using our Telegraf Google Storage Transfer metrics example configuration.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Storage Transfer, Data Transfer, Cloud Storage, Service
 ---
 
 Configure Telegraf to ship Google Storage Transfer metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/tasks-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/tasks-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudTasks
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google Cloud Tasks metrics to Logit.io. Configure Telegraf to send Google Cloud Tasks metrics to ELK.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Cloud Tasks, Task Queue
 ---
 
 Configure Telegraf to ship Google Cloud Tasks metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/tpu-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/tpu-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudTpu
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google Cloud TPU metrics to Logit.io. Configure Telegraf to send Google Cloud TPU metrics to Logstash or Elastic.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Cloud TPU, Tensor Processing Unit, Tpu
 ---
 
 Configure Telegraf to ship Google Cloud TPU metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/trace-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/trace-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudTrace
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google Cloud Trace metrics to Logit.io. Configure Telegraf to send Google Cloud Trace metrics to ELK.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Cloud Trace, Distributed Tracing
 ---
 
 Configure Telegraf to ship Google Cloud Trace metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/vertex-ai-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/vertex-ai-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google Vertex AI metrics to Logit.io. Configure Telegraf to send Google Vertex AI metrics to Logstash or Elastic.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Vertex AI, Artificial Intelligence, Machine Learning, Ai
 ---
 
 Configure Telegraf to ship Google Vertex AI metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/vm-manager-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/vm-manager-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google VM Manager metrics to Logit.io. Configure Telegraf to send Google VM Manager metrics to ELK.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google VM Manager, Virtual Machine, Cloud Computing, Vm
 ---
 
 Configure Telegraf to ship Google VM Manager metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/vpc-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/vpc-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google VPC metrics to your Logit.io stacks. Configure Telegraf to send Google VPC metrics to Logstash or Elastic.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google VPC, Virtual Private Cloud, Networking, Vpc
 ---
 
 Configure Telegraf to ship Google VPC metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/vpn-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/vpn-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: GoogleCloudVpn
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google Cloud VPN metrics to Logit.io. Configure Telegraf to send Google Cloud VPN metrics to Logstash or Elastic.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Cloud VPN, Virtual Private Network, Vpn
 ---
 
 Configure Telegraf to ship Google Cloud VPN metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/google-cloud/workflows-telegraf-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/google-cloud/workflows-telegraf-metrics.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#3c76d7"
 description: Use our example to configure Telegraf to ship Google Workflows metrics to Logit.io. Configure Telegraf to send Google Workflows metrics to Logstash or Elastic.
 stackTypes: metrics
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Google Workflows, Workflow Automation, Orchestration
 ---
 
 Configure Telegraf to ship Google Workflows metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/languages-and-libraries/metricbeat-module-golang.mdx
+++ b/src/pages/integrations/infrastructure-metrics/languages-and-libraries/metricbeat-module-golang.mdx
@@ -6,6 +6,7 @@ color: "#00b1d1"
 description: How to send Golang server metrics to your Hosted ELK Logstash instance. Get started using our Metricbeat Golang server module example configurations.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: GoLang, Go, GoMetrics, Metricbeat, Monitoring, Performance, Instrumentation, Metrics Collection, Observability, Logs, Log Analysis, DevOps, System Metrics, Application Metrics, Module, Golang
 ---
 
 Metricbeat is a lightweight shipper that helps you monitor your Golang servers by collecting 

--- a/src/pages/integrations/infrastructure-metrics/message-queues/metricbeat-module-rabbitmq.mdx
+++ b/src/pages/integrations/infrastructure-metrics/message-queues/metricbeat-module-rabbitmq.mdx
@@ -6,6 +6,7 @@ color: "#f66000"
 description: How to send RabbitMQ message queue metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send RabbitMQ metrics to Logstash or Elasticsearch.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Metrics, Metricbeat, Stats, RabbitMQ, Message Queue, Module, Rabbitmq
 ---
 
 Metricbeat is a lightweight shipper that helps you monitor RabbitMQ server 

--- a/src/pages/integrations/infrastructure-metrics/message-queues/metricbeat-module-redis.mdx
+++ b/src/pages/integrations/infrastructure-metrics/message-queues/metricbeat-module-redis.mdx
@@ -6,6 +6,7 @@ color: "#c40d00"
 description: How to send Redis server metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send Redis server metrics to Logstash or Elasticsearch.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Metrics, Metricbeat, Stats, Redis, Module
 ---
 
 Metricbeat is a lightweight shipper that helps you monitor your Redis 

--- a/src/pages/integrations/infrastructure-metrics/open-telemetry/otel-collector-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/open-telemetry/otel-collector-metrics.mdx
@@ -6,6 +6,7 @@ color: "#2e62a4"
 description: The OpenTelemetry Collector sends logs, metrics and traces to your ELK stack. Configure OTEL Collector to send data to Logstash and Elasticsearch.     
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: OTEL, OTEL Collector, OpenTelemetry, Metrics, Telemetry
 ---
 
 The OpenTelemetry Collector allows you to send metrics to your Logit.io stacks. 

--- a/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-system-centos.mdx
+++ b/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-system-centos.mdx
@@ -6,6 +6,7 @@ color: "#001a52"
 description: Sending System Metrics from CentOS to Your Hosted ELK Logstash Instance - Configuring Metricbeat for Transmission to Logstash or Elasticsearch.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Metrics, Metricbeat, Stats, System, CentOS, Module, Centos
 ---
 
 Metricbeat is a lightweight shipper that helps you monitor your servers 

--- a/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-system-debian.mdx
+++ b/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-system-debian.mdx
@@ -6,6 +6,7 @@ color: "#a80030"
 description: How to send Debian System metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send Debian System metrics to Logstash or Elasticsearch.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Metrics, Metricbeat, Stats, System, Debian, Module
 ---
 
 Metricbeat is a lightweight shipper that helps you monitor your servers by collecting metrics from the operating system and from services 

--- a/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-system-macos.mdx
+++ b/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-system-macos.mdx
@@ -6,6 +6,7 @@ color: "#3c76d7"
 description: How to send macOS System metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send macOS System metrics to Logstash or Elasticsearch.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Metrics, Metricbeat, Stats, System, MacOS, Apple, OSX, Mojave, Operating System Monitor, Module, Macos
 ---
 
 Metricbeat is a lightweight shipper that helps you monitor your servers by 

--- a/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-system-redhat.mdx
+++ b/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-system-redhat.mdx
@@ -7,6 +7,7 @@ color: "#ee0000"
 description: Transmitting Red Hat (RHEL) System Metrics to Your Hosted ELK Logstash Instance - Configuring Metricbeat to Send Red Hat Metrics to Logstash or Elasticsearch.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Metrics, Metricbeat, Stats, System, RedHat, Red Hat, RHEL, Fedora, Operating System Monitor, Module, Redhat
 ---
 
 Metricbeat is a lightweight shipper that helps you monitor your servers by 

--- a/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-system-ubuntu.mdx
+++ b/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-system-ubuntu.mdx
@@ -6,6 +6,7 @@ color: "#e95521"
 description: Sending Ubuntu System Metrics to Your Hosted ELK Logstash Instance - Configuring Metricbeat for Transmitting System Metrics to Logstash or Elasticsearch.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Metrics, Metricbeat, Stats, System, Ubuntu, Operating System Monitor, Module
 ---
 
 Metricbeat is a lightweight shipper that helps you monitor your servers by collecting 

--- a/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-system-windows.mdx
+++ b/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-system-windows.mdx
@@ -6,6 +6,7 @@ color: "#00aae5"
 description: How to send Windows System metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send Windows System metrics to Logstash or Elasticsearch. 
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Metrics, Metricbeat, Stats, System, Microsoft, Windows, Operating System Monitor, Module
 ---
 
 Metricbeat is a lightweight shipper that helps you monitor your servers by 

--- a/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-uwsgi.mdx
+++ b/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-uwsgi.mdx
@@ -6,6 +6,7 @@ color: "#93b20f"
 description: How to send uWSGI metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send uWSGI server metrics to Logstash or Elasticsearch.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Metrics, Metricbeat, Stats, uWSGI, Application Server, Module, Uwsgi
 ---
 
 Metricbeat is a lightweight shipper that helps you monitor your uWSGI 

--- a/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-windows.mdx
+++ b/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-windows.mdx
@@ -6,6 +6,7 @@ color: "#00aae5"
 description: How to send Windows services & performance counter metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send Windows metrics to Logstash.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Metrics, Metricbeat, Stats, System, Microsoft, Windows, Operating System Monitor, Module
 ---
 
 Metricbeat is a lightweight shipper that helps you monitor your Windows server 

--- a/src/pages/integrations/infrastructure-metrics/platforms/metricbeat-module-apache.mdx
+++ b/src/pages/integrations/infrastructure-metrics/platforms/metricbeat-module-apache.mdx
@@ -6,6 +6,7 @@ color: "#cc2235"
 description: How to send Apache server metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send Apache HTTPD server metrics to Logstash or Elasticsearch. 
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Metrics, Metricbeat, Stats, Apache, Apache2, HTTP, HTTPd, Web, Web Server, Module
 ---
 
 Metricbeat is a lightweight shipper that helps you monitor your Apache HTTPD 

--- a/src/pages/integrations/infrastructure-metrics/platforms/metricbeat-module-docker.mdx
+++ b/src/pages/integrations/infrastructure-metrics/platforms/metricbeat-module-docker.mdx
@@ -6,6 +6,7 @@ color: "#008bb6"
 description: How to send Docker container metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send Docker container metrics to Logstash or Elasticsearch. 
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Metrics, Metricbeat, Stats, Docker, Container, Containerization, Module
 ---
 
 Metricbeat is a lightweight shipper that helps you monitor Docker by collecting 

--- a/src/pages/integrations/infrastructure-metrics/platforms/metricbeat-module-haproxy.mdx
+++ b/src/pages/integrations/infrastructure-metrics/platforms/metricbeat-module-haproxy.mdx
@@ -6,6 +6,7 @@ color: "#009edb"
 description: How to send HAProxy metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send HAProxy server metrics to Logstash or Elasticsearch. 
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Metrics, Metricbeat, Stats, HAProxy, Proxy, Web, HTTP, Load Balancer, Module, Haproxy
 ---
 
 Metricbeat is a lightweight shipper that helps you monitor your HAProxy servers 

--- a/src/pages/integrations/infrastructure-metrics/platforms/metricbeat-module-kafka.mdx
+++ b/src/pages/integrations/infrastructure-metrics/platforms/metricbeat-module-kafka.mdx
@@ -6,6 +6,7 @@ color: "#723244"
 description: How to send Kafka server metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send Apache Kafka server metrics to Logstash or Elasticsearch. 
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Metrics, Metricbeat, Stats, Kafka, Message Queue, Module
 ---
 
 Metricbeat is a lightweight shipper that helps you monitor your Kafka servers 

--- a/src/pages/integrations/infrastructure-metrics/platforms/metricbeat-module-kubernetes.mdx
+++ b/src/pages/integrations/infrastructure-metrics/platforms/metricbeat-module-kubernetes.mdx
@@ -6,6 +6,7 @@ color: "#3a64ad"
 description: How to send Kubernetes container metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send Kubernetes container metrics to Logstash.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Metrics, Metricbeat, Stats, Kubernetes, K8s, Container Orchestration, Module
 ---
 
 Metricbeat is a lightweight shipper that helps you monitor Kubernetes by 

--- a/src/pages/integrations/infrastructure-metrics/platforms/metricbeat-module-nginx.mdx
+++ b/src/pages/integrations/infrastructure-metrics/platforms/metricbeat-module-nginx.mdx
@@ -6,6 +6,7 @@ color: "#00aa4e"
 description: How to send NGINX server metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send NGINX web server metrics to Logstash or Elasticsearch. 
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Metrics, Metricbeat, Stats, Nginx, Web, HTTP, Web Server, Module
 ---
 
 Metricbeat is a lightweight shipper that helps you monitor your NGINX web 

--- a/src/pages/integrations/infrastructure-metrics/platforms/metricbeat-module-zookeeper.mdx
+++ b/src/pages/integrations/infrastructure-metrics/platforms/metricbeat-module-zookeeper.mdx
@@ -6,6 +6,7 @@ color: "#437e2d"
 description: Follow our Apache Zookeeper tutorial to ship Apache Zookeeper Server Metrics Logstash for monitoring and analysis. 
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Metrics, Metricbeat, Stats, System, Microsoft, Windows, Apache, Zookeeper, Distributed Systems, Module
 ---
 
 Metricbeat is a lightweight shipper that helps you monitor your Apache ZooKeeper 

--- a/src/pages/integrations/infrastructure-metrics/protocols/metricbeat-module-http.mdx
+++ b/src/pages/integrations/infrastructure-metrics/protocols/metricbeat-module-http.mdx
@@ -6,6 +6,7 @@ color: "#30a743"
 description: How to send HTTP endpoint server metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send HTTP endpoint server metrics to Elasticsearch.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Metrics, Metricbeat, Stats, HTTP, API, Module, Http
 ---
 
 Metricbeat is a lightweight shipper that helps you monitor your servers 

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-activemq.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-activemq.mdx
@@ -6,6 +6,7 @@ color: "#d10066"
 description: Use our example to configure Telegraf to ship ActiveMQ metrics to your Logit.io stacks. Configure Telegraf to send ActiveMQ metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, ActiveMQ, Prometheus, Messaging, JMS, Message Broker, Java Message Service, Activemq
 ---
 
 Configure Telegraf to ship ActiveMQ metrics to your Logit.io stacks via Logstash. 

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-aerospike.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-aerospike.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Aerospike metrics to your Logit.io stacks. Configure Telegraf to send Aerospike metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Aerospike, Prometheus, NoSQL, Database, Distributed Database
 ---
 
 Configure Telegraf to ship Aerospike metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-apache-aurora.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-apache-aurora.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Configure Telegraf to ship Apache Aurora Server metrics to Logit.io. Get started using our Telegraf Apache Aurora Server metrics example configuration.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Apache Aurora, Prometheus, Server, Distributed System
 ---
 
 Configure Telegraf to ship Apache Aurora Server metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-apache-cassandra.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-apache-cassandra.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Apache Cassandra metrics to Logit.io. Configure Telegraf to send Apache Cassandra metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Apache Cassandra, Prometheus, Database, NoSQL
 ---
 
 Configure Telegraf to ship Apache Cassandra metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-apache-https.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-apache-https.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Apache HTTP Server metrics to Logit.io. Configure Telegraf to send Apache HTTP Server metrics to ELK.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Apache HTTP Server, Prometheus, Web Server, Http
 ---
 
 Configure Telegraf to ship Apache HTTP Server metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-apache-mesos.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-apache-mesos.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Apache Mesos metrics to Logit.io. Configure Telegraf to send Apache Mesos metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Prometheus, Apache Mesos, Container Orchestration, Distributed System
 ---
 
 Configure Telegraf to ship Apache Mesos metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-apache-solr.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-apache-solr.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Apache Solr metrics to Logit.io. Configure Telegraf to send Apache Solr metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Apache Solr, Prometheus, Search Engine, Lucene
 ---
 
 Configure Telegraf to ship Apache Solr metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-apache-tomcat.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-apache-tomcat.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Apache Tomcat metrics to Logit.io. Configure Telegraf to send Apache Tomcat metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Apache Tomcat, Prometheus, Application Server, Servlet Container
 ---
 
 Configure Telegraf to ship Apache Tomcat metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-argo-cd.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-argo-cd.mdx
@@ -5,6 +5,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Argo CD metrics to your Logit.io stacks. Configure Telegraf to send Argo CD metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Prometheus, Argo CD, Continuous Delivery, GitOps, Cd
 ---
 
 Configure Telegraf to ship Argo CD metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-bcache.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-bcache.mdx
@@ -5,6 +5,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship bCache metrics to your Logit.io stacks. Configure Telegraf to send bCache metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, bCache, Prometheus, Cache, Linux Cache, Bcache
 ---
 
 Configure Telegraf to ship bCache metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-beanstalkd.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-beanstalkd.mdx
@@ -5,6 +5,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Beanstalkd metrics to your Logit.io stacks. Configure Telegraf to send Beanstalkd metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Beanstalkd, Prometheus, Message Queue, Job Queue
 ---
 
 Configure Telegraf to ship Beanstalkd metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-bond.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-bond.mdx
@@ -5,6 +5,7 @@ color: "#4d4d4d"
 description: Use our example to set up Telegraf for Sending Bond Metrics to Your Logit.io Stacks. Configure Telegraf to Transmit Bond Metrics to Logstash or Elasticsearch.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Bond, Prometheus, Networking, Network Bonding
 ---
 
 Configure Telegraf to ship Bond metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-burrows.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-burrows.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Burrow metrics to your Logit.io stacks. Configure Telegraf to send Burrow metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Burrow, Prometheus, Kafka Consumer Lag
 ---
 
 Configure Telegraf to ship Burrow metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-ceph.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-ceph.mdx
@@ -5,6 +5,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Ceph metrics to your Logit.io stacks. Configure Telegraf to send Ceph metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Prometheus, Ceph, Distributed Storage
 ---
 
 Configure Telegraf to ship Ceph metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-clickhouse.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-clickhouse.mdx
@@ -5,6 +5,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship ClickHouse metrics to your Logit.io stacks. Configure Telegraf to send ClickHouse metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, ClickHouse, Prometheus, Columnar Database, Clickhouse
 ---
 
 Configure Telegraf to ship ClickHouse metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-couchdb.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-couchdb.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship CouchDB metrics to your Logit.io stacks. Configure Telegraf to send CouchDB metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, CouchDB, Prometheus, NoSQL, Database, Couchdb
 ---
 
 Configure Telegraf to ship CouchDB metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-disque.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-disque.mdx
@@ -5,6 +5,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Disque metrics to your Logit.io stacks. Configure Telegraf to send Disque metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Disque, Prometheus, In-Memory Database
 ---
 
 Configure Telegraf to ship Disque metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-dovecot.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-dovecot.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Dovecot metrics to your Logit.io stacks. Configure Telegraf to send Dovecot metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Dovecot, Prometheus, Email Server, IMAP
 ---
 
 Configure Telegraf to ship Dovecot metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-elasticsearch.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-elasticsearch.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Elasticsearch metrics to Logit.io. Configure Telegraf to send Elasticsearch metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Elasticsearch, Prometheus, Search, NoSQL
 ---
 
 Configure Telegraf to ship Elasticsearch metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-etcd.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-etcd.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship etcd metrics to your Logit.io stacks. Configure Telegraf to send etcd metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, etcd, Prometheus, Distributed System, Key-Value Store, Etcd
 ---
 
 Configure Telegraf to ship etcd metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-fail2ban.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-fail2ban.mdx
@@ -5,6 +5,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Fail2ban metrics to your Logit.io stacks. Configure Telegraf to send Fail2ban metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Fail2ban, Prometheus, Security, Threat Detection
 ---
 
 Configure Telegraf to ship Fail2ban metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-github.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-github.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Github metrics to your Logit.io stacks. Configure Telegraf to send Github metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Github, Prometheus, Version Control, Collaboration
 ---
 
 Configure Telegraf to ship Github metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-haproxy.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-haproxy.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship HAproxy metrics to your Logit.io stacks. Configure Telegraf to send HAproxy metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, HAProxy, Load Balancer, Haproxy
 ---
 
 Configure Telegraf to ship HAproxy metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-ipmi.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-ipmi.mdx
@@ -5,6 +5,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship IPMI metrics to your Logit.io stacks. Configure Telegraf to send IPMI metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, IPMI, Intelligent Platform Management Interface, Ipmi
 ---
 
 Configure Telegraf to ship IPMI metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-jenkins.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-jenkins.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Jenkins metrics to your Logit.io stacks. Configure Telegraf to send Jenkins metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Jenkins, Continuous Integration, CI/CD, Telegraf, Jenkins
 ---
 
 Configure Telegraf to ship Jenkins metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-jti-openconfig.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-jti-openconfig.mdx
@@ -5,6 +5,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship JTI OpenConfig metrics to Logit.io. Configure Telegraf to send JTI OpenConfig metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, JTI OpenConfig, Streaming Data, Jti, Openconfig
 ---
 
 Configure Telegraf to ship JTI OpenConfig metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-mailchimp.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-mailchimp.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Mailchimp metrics to your Logit.io stacks. Configure Telegraf to send Mailchimp metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Mailchimp, Email Marketing
 ---
 
 Configure Telegraf to ship Mailchimp metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-mcrouter.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-mcrouter.mdx
@@ -5,6 +5,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Mcrouter to your Logit.io stacks. Configure Telegraf to send Mcrouter to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, mcrouter, Memcached Router, Mcrouter
 ---
 
 Configure Telegraf to ship Mcrouter to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-memcached.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-memcached.mdx
@@ -5,6 +5,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Memcached metrics to your Logit.io stacks. Configure Telegraf to send Memcached metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Memcached, Caching
 ---
 
 Configure Telegraf to ship Memcached metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-mongodb.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-mongodb.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship MongoDB Server metrics to Logit.io. Configure Telegraf to send MongoDB Server metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, MongoDB, NoSQL, Mongodb
 ---
 
 Configure Telegraf to ship MongoDB Server metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-mysql.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-mysql.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship MySQL Server metrics to Logit.io. Configure Telegraf to send MySQL Server metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, MySQL, Database, Mysql
 ---
 
 Configure Telegraf to ship MySQL Server metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-neptune-apex.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-neptune-apex.mdx
@@ -5,6 +5,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Neptune Apex metrics to Logit.io. Configure Telegraf to send Neptune Apex metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Neptune Apex, Database, Monitoring, Cloud
 ---
 
 Configure Telegraf to ship Neptune Apex metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-nginx.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-nginx.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Nginx metrics to your Logit.io stacks. Configure Telegraf to send Nginx metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Nginx, Web Server, Monitoring, Performance
 ---
 
 Configure Telegraf to ship Nginx metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-nsq-consumer.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-nsq-consumer.mdx
@@ -5,6 +5,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship NSQ Consumer metrics to Logit.io. Configure Telegraf to send NSQ Consumer metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, NSQ Consumer, Messaging, Monitoring, Message Queue, Nsq
 ---
 
 Configure Telegraf to ship NSQ Consumer metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-nsq.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-nsq.mdx
@@ -5,6 +5,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship NSQ metrics to your Logit.io stacks. Configure Telegraf to send NSQ metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, NSQ, Messaging, Monitoring, Message Queue, Nsq
 ---
 
 Configure Telegraf to ship NSQ metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-nvidia.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-nvidia.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Nvidia SMI Metrics to your Logit.io stacks. Configure Telegraf to send Nvidia SMI Metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Nvidia, GPU, Monitoring, Hardware
 ---
 
 Configure Telegraf to ship Nvidia SMI Metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-opensearch.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-opensearch.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship OpenSearch metrics to your Logit.io stacks. Configure Telegraf to send OpenSearch metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, OpenSearch, Search Engine, Monitoring, Database, Opensearch
 ---
 
 Configure Telegraf to ship OpenSearch metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-pg-bouncer.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-pg-bouncer.mdx
@@ -5,6 +5,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship PgBouncer metrics to your Logit.io stacks. Configure Telegraf to send PgBouncer metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, PgBouncer, Database, Monitoring, Database Connection, Pgbouncer
 ---
 
 Configure Telegraf to ship PgBouncer metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-php-fpm.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-php-fpm.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship PHP-FPM metrics to your Logit.io stacks. Configure Telegraf to send PHP-FPM metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, PHP-FPM, PHP, Monitoring, Web, Application Server, Php, Fpm
 ---
 
 Configure Telegraf to ship PHP-FPM metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-phusion.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-phusion.mdx
@@ -5,6 +5,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Phusion Passenger metrics to Logit.io. Configure Telegraf to send Phusion Passenger metrics to ELK.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Phusion, Application Server, Monitoring, Web
 ---
 
 Configure Telegraf to ship Phusion Passenger metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-postgresql.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-postgresql.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship PostgreSQL metrics to Logit.io. Configure Telegraf to send PostgreSQL metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, PostgreSQL, Database, Monitoring, Database Management, Postgresql
 ---
 
 Configure Telegraf to ship PostgreSQL metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-prometheus.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-prometheus.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Prometheus metrics to your Logit.io stacks. Configure Telegraf to send Prometheus metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Prometheus, Monitoring
 ---
 
 Configure Telegraf to ship Prometheus metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-rabbitmq.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-rabbitmq.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship RabbitMQ metrics to your Logit.io stacks. Configure Telegraf to send RabbitMQ metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, RabbitMQ, Message Queue, Monitoring, Messaging, Rabbitmq
 ---
 
 Configure Telegraf to ship RabbitMQ metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-ravendb.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-ravendb.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship RavenDB metrics to your Logit.io stacks. Configure Telegraf to send RavenDB metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, RavenDB, Database, Monitoring, Ravendb
 ---
 
 Configure Telegraf to ship RavenDB metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-redfish.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-redfish.mdx
@@ -5,6 +5,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Redfish metrics to your Logit.io stacks. Configure Telegraf to send Redfish metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Redfish, Hardware Management, Monitoring
 ---
 
 Configure Telegraf to ship Redfish metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-redis.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-redis.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Redis metrics to your Logit.io stacks. Configure Telegraf to send Redis metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Redis, Database, Monitoring
 ---
 
 Configure Telegraf to ship Redis metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-riak.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-riak.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Riak metrics to your Logit.io stacks. Configure Telegraf to send Riak metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Riak, Database, Monitoring
 ---
 
 Configure Telegraf to ship Riak metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-sql-server.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-sql-server.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship SQL Server metrics to your Logit.io stacks. Configure Telegraf to send SQL Server metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, SQL Server, Database, Monitoring, Sql
 ---
 
 Configure Telegraf to ship SQL Server metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-suricata.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-suricata.mdx
@@ -5,6 +5,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Suricata metrics to your Logit.io stacks. Configure Telegraf to send Suricata metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Suricata, Network Security, Monitoring
 ---
 
 Configure Telegraf to ship Suricata metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-synproxy.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-synproxy.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Synproxy metrics to your Logit.io stacks. Configure Telegraf to send Synproxy metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Synproxy, Security, Monitoring
 ---
 
 Configure Telegraf to ship Synproxy metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-system_metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-system_metrics.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship system metrics to your Logit.io stacks. Configure Telegraf to send system metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, Health, Instrumentation, System Metrics, Monitoring
 ---
 
 Configure Telegraf to ship system metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-teamcity.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-teamcity.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship TeamCity Server metrics to Logit.io. Configure Telegraf to send TeamCity Server metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, TeamCity, Continuous Integration, Monitoring, Teamcity
 ---
 
 Configure Telegraf to ship TeamCity Server metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-tengine.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-tengine.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Tengine metrics to your Logit.io stacks. Configure Telegraf to send Tengine metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Tengine, Web Server
 ---
 
 Configure Telegraf to ship Tengine metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-unbound.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-unbound.mdx
@@ -5,6 +5,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Unbound metrics to your Logit.io stacks. Configure Telegraf to send Unbound metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Unbound, DNS
 ---
 
 Configure Telegraf to ship Unbound metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-vmware-vsphere.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-vmware-vsphere.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Vmware Vsphere metrics to Logit.io. Configure Telegraf to send Vmware Vsphere metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, VMware vSphere, Virtualization, Vmware, Vsphere
 ---
 
 Configure Telegraf to ship Vmware Vsphere metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-windows-performance.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-windows-performance.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Windows Performance metrics to Logit.io. Configure Telegraf to send Windows Performance metrics to ELK.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Windows, Performance Metrics
 ---
 
 Configure Telegraf to ship Windows Performance metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-windows-service.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-windows-service.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Windows Services metrics to Logit.io. Configure Telegraf to send Windows Services metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Windows, Services, Service
 ---
 
 Configure Telegraf to ship Windows Services metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-wireguard.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-wireguard.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Wireguard metrics to your Logit.io stacks. Configure Telegraf to send Wireguard metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Wireguard, Security
 ---
 
 Configure Telegraf to ship Wireguard metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-youtube.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-youtube.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship YouTube metrics to your Logit.io stacks. Configure Telegraf to send YouTube metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, YouTube, Video, Youtube
 ---
 
 Configure Telegraf to ship YouTube metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-zfs.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-zfs.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship ZFS metrics to your Logit.io stacks. Configure Telegraf to send ZFS metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, ZFS, File System, Zfs
 ---
 
 Configure Telegraf to ship ZFS metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-zookeeper.mdx
+++ b/src/pages/integrations/infrastructure-metrics/telegraf/telegraf-zookeeper.mdx
@@ -6,6 +6,7 @@ color: "#4d4d4d"
 description: Use our example to configure Telegraf to ship Zookeeper metrics to your Logit.io stacks. Configure Telegraf to send Zookeeper metrics to Logstash or Elastic.
 stackTypes: metrics
 sslPortType: beats-ssl
+tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Zookeeper, Distributed System
 ---
 
 Configure Telegraf to ship Zookeeper metrics to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/infrastructure-metrics/time-series-database/azure-aks-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/time-series-database/azure-aks-metrics.mdx
@@ -5,6 +5,7 @@ logo: AKS
 color: "#834c9a"
 description: Send Azure AKS Metrics to VictoriaMetrics using the vmagent instructions below and begin analysing your data
 stackTypes: metrics
+tags: Metrics, VictoriaMetrics, Prometheus, VMagent, Azure, Azure Kubernetes, AKS, Cloud Metrics, Azure Aks Metrics
 ---
 
 Vmagent is a tiny but mighty agent which helps you collect 

--- a/src/pages/integrations/infrastructure-metrics/time-series-database/vmagent.mdx
+++ b/src/pages/integrations/infrastructure-metrics/time-series-database/vmagent.mdx
@@ -4,6 +4,7 @@ subTitle: Ship metrics using VictoriaMetrics vmagent
 logo: victoriametrics
 description: Send Kubernetes Metrics to VictoriaMetrics using the vmagent instructions below and begin searching your data
 stackTypes: metrics
+tags: VictoriaMetrics, Prometheus, VMagent, Metrics, Time Series Database, Kubernetes, Vmagent
 ---
 
 Vmagent is a tiny but mighty agent which helps you collect 

--- a/src/pages/integrations/log-management.mdx
+++ b/src/pages/integrations/log-management.mdx
@@ -1,7 +1,6 @@
 ---
 title: Log Management
 description: Follow the steps outlined in Logit.io's log management source integrations to begin shipping various logs to Logit.io.
-stackTypes: logs
 pagination: false
 timestamp: false
 ---

--- a/src/pages/integrations/log-management.mdx
+++ b/src/pages/integrations/log-management.mdx
@@ -1,6 +1,7 @@
 ---
 title: Log Management
 description: Follow the steps outlined in Logit.io's log management source integrations to begin shipping various logs to Logit.io.
+stackTypes: logs
 pagination: false
 timestamp: false
 ---

--- a/src/pages/integrations/log-management/applications/activemq.mdx
+++ b/src/pages/integrations/log-management/applications/activemq.mdx
@@ -6,6 +6,7 @@ color: "#d10066"
 description: Use Filebeat to send ActiveMQ application logs to your hosted ELK stacks. Get started using our Filebeat ActiveMQ example configurations.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: logs, ActiveMQ, queue, message, Queue, Message, JMS, Messaging, Activemq
 ---
 
 Filebeat is a lightweight shipper that enables you to send your ActiveMQ message queue logs to Logstash and Elasticsearch. 

--- a/src/pages/integrations/log-management/applications/activemq.mdx
+++ b/src/pages/integrations/log-management/applications/activemq.mdx
@@ -6,7 +6,7 @@ color: "#d10066"
 description: Use Filebeat to send ActiveMQ application logs to your hosted ELK stacks. Get started using our Filebeat ActiveMQ example configurations.
 stackTypes: logs
 sslPortType: beats-ssl
-tags: logs, ActiveMQ, queue, message, Queue, Message, JMS, Messaging, Activemq
+tags: logs, ActiveMQ, Queue, Message, JMS, Messaging, Activemq, App
 ---
 
 Filebeat is a lightweight shipper that enables you to send your ActiveMQ message queue logs to Logstash and Elasticsearch. 

--- a/src/pages/integrations/log-management/applications/apache-storm.mdx
+++ b/src/pages/integrations/log-management/applications/apache-storm.mdx
@@ -6,6 +6,7 @@ color: "#215593"
 description: Utilize the provided instructions to transmit your Apache Storm logs to logit.io through logstash, initiating the data search process.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Apache, Storm, Big Data, Stream Processing
 ---
 
 Utilize the provided instructions to transmit your Apache Storm 

--- a/src/pages/integrations/log-management/applications/apache.mdx
+++ b/src/pages/integrations/log-management/applications/apache.mdx
@@ -6,6 +6,7 @@ color: "#cc2235"
 description: Learn how to use Filebeat to send Apache application, access or error logs to your Logit.io stacks. Configure Filebeat to send Apache logs to ELK.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: logs, metrics, Apache, Apache2, HTTP, HTTPD, Web, WebServer, HTTP
 ---
 
 Use Filebeat to ship access and error logs from Apache to your Logit.io Stack.

--- a/src/pages/integrations/log-management/applications/auditd.mdx
+++ b/src/pages/integrations/log-management/applications/auditd.mdx
@@ -5,6 +5,7 @@ color: "#f19b00"
 description: Configure Filebeat using the pre-defined examples below to start sending your Auditd logs. Send your Auditd application logs to Logstash and Elasticsearch.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, Audit, Auditing, Security Logs, Auditd
 ---
 
 Filebeat is a lightweight shipper that enables you to send your Auditd application 

--- a/src/pages/integrations/log-management/applications/avast.mdx
+++ b/src/pages/integrations/log-management/applications/avast.mdx
@@ -6,6 +6,7 @@ color: "#FF7800"
 description: Follow our Avast tutorial to get started shipping logs from Avast to Logstash for monitoring and analysis in Logit.io.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Antivirus, Cybersecurity, System, Security Software, Avast
 ---
 
 Follow our Avast tutorial to get started shipping logs from Avast to Logstash for monitoring and analysis in Logit.io.

--- a/src/pages/integrations/log-management/applications/axonius.mdx
+++ b/src/pages/integrations/log-management/applications/axonius.mdx
@@ -6,6 +6,7 @@ color: "#F26422"
 description: Send your Axonius logs to logit.io via logstash using the instructions below and begin searching your data
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Cybersecurity, System, Security Management, Axonius
 ---
 
 Send your Axonius logs to logit.io via logstash using the instructions below and begin searching your data.

--- a/src/pages/integrations/log-management/applications/cisco-asa.mdx
+++ b/src/pages/integrations/log-management/applications/cisco-asa.mdx
@@ -6,6 +6,7 @@ color: "#c5112e"
 description: Use our example to configure Filebeat to ship Cisco logs to Logstash and Elasticsearch. Send Cisco logs to your Logit.io stacks.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Beats, Logs, Filebeat, Cisco, ASA, Firewall, Security Logs, Cisco Asa
 ---
 
 Configure Filebeat to ship Cisco logs to Logstash and Elasticsearch.

--- a/src/pages/integrations/log-management/applications/cynet.mdx
+++ b/src/pages/integrations/log-management/applications/cynet.mdx
@@ -6,6 +6,7 @@ logo: cynet
 description: Send your Cynet logs to logit.io via Logstash using the instructions below and begin searching your data
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Cybersecurity, System, Security Management, Cynet
 ---
 
 Send your Cynet logs to logit.io via Logstash using the instructions below and begin searching your data.

--- a/src/pages/integrations/log-management/applications/haproxy.mdx
+++ b/src/pages/integrations/log-management/applications/haproxy.mdx
@@ -6,6 +6,7 @@ color: "#009edb"
 description: Use Filebeat to send HAProxy application, access or error logs to your ELK stacks. Configure Filebeat to send HAProxy logs to logstash or Elasticsearch. 
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, HAProxy, Proxy, Load Balancer, Ingress, HTTP, Web Server, Web Traffic, Haproxy
 ---
 
 Configure Filebeat to ship logs from HAProxy to Logstash and Elasticsearch.

--- a/src/pages/integrations/log-management/applications/hashicorp.mdx
+++ b/src/pages/integrations/log-management/applications/hashicorp.mdx
@@ -6,6 +6,7 @@ color: "#FFD815"
 description: Send your HashiCorp Vault logs to logit.io via logstash using the instructions below and begin searching your data
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Audit Device, Hashi, Vault, Hashicorp, Security
 ---
 
 Send your HashiCorp Vault logs to logit.io via logstash using the 

--- a/src/pages/integrations/log-management/applications/iis.mdx
+++ b/src/pages/integrations/log-management/applications/iis.mdx
@@ -7,6 +7,7 @@ color: "#0adef"
 description: Get started with analysing IIS logs with our easy integration allowing you to ship application logs from Filebeat to Logstash & Elasticsearch (ELK).
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, IIS, Microsoft, Windows, HTTP, Web, Web Server, Internet Information Services, .NET Framework, Iis
 ---
 
 Send your HashiCorp Vault logs to logit.io via logstash 

--- a/src/pages/integrations/log-management/applications/jenkins.mdx
+++ b/src/pages/integrations/log-management/applications/jenkins.mdx
@@ -5,6 +5,7 @@ logo: jenkins
 description: Send your Jenkins logs to logit.io via Logstash using the instructions below and begin searching your data
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Automation, Deployment, CI/CD, Jenkins, Jenkins
 ---
 
 Send your Jenkins logs to logit.io via Logstash using 

--- a/src/pages/integrations/log-management/applications/kafka.mdx
+++ b/src/pages/integrations/log-management/applications/kafka.mdx
@@ -6,6 +6,7 @@ color: "#723244"
 description: Use our example to configure Filebeat to send your Apache Kafka application logs to Logstash and Elasticsearch. Configure Filebeat to ship logs to Logit.io.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, Apache Kafka, App
 ---
 
 Filebeat is a lightweight shipper that enables you to send your Apache Kafka 

--- a/src/pages/integrations/log-management/applications/kong.mdx
+++ b/src/pages/integrations/log-management/applications/kong.mdx
@@ -6,6 +6,7 @@ color: "#2cb391"
 description: Send your kong application/access/error logs to Logit.io via Logstash using the instructions below and begin searching your data
 stackTypes: logs
 sslPortType: tcp-ssl
+tags: Logs, Kong, Nginx, Service Mesh
 ---
 
 Send your Kong application/access/error logs to Logit.io via Logstash 

--- a/src/pages/integrations/log-management/applications/mcafee-epo.mdx
+++ b/src/pages/integrations/log-management/applications/mcafee-epo.mdx
@@ -7,6 +7,7 @@ color: "#c01818"
 description: Send your McAfee EPO Logs to logit.io via logstash using the instructions below and begin searching your data
 stackTypes: logs
 sslPortType: syslog-ssl
+tags: Logs, McAfee, Syslog, Mcafee Epo
 ---
 
 Send your McAfee EPO Logs to logit.io via logstash using the instructions below and begin searching your data.

--- a/src/pages/integrations/log-management/applications/mongodb.mdx
+++ b/src/pages/integrations/log-management/applications/mongodb.mdx
@@ -6,6 +6,7 @@ color: "#00684a"
 description: Discover the process of transmitting MongoDB logs to your Logstash instance through our illustrative configuration examples.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, MongoDB, Database, NoSQL, DB, Mongodb
 ---
 
 Discover the process of transmitting MongoDB logs to your Logstash instance through our illustrative configuration examples.

--- a/src/pages/integrations/log-management/applications/mulesoft.mdx
+++ b/src/pages/integrations/log-management/applications/mulesoft.mdx
@@ -6,6 +6,7 @@ color: "#00a1df"
 description: Use our example to configure log4j to send MuleSoft log data to Logit.io. Start shipping Mule application logging entries to Logstash or Elasticsearch.
 stackTypes: logs
 sslPortType: tcp-ssl
+tags: Mulesoft, Mule, Logs, Anypoint Studio, AnypointStudio, Log4j, ESB
 ---
 
 Use AnypointStudio and configure log4j using Socket Appender to ship Mule application logging entries to Logstash or Elasticsearch.

--- a/src/pages/integrations/log-management/applications/mysql.mdx
+++ b/src/pages/integrations/log-management/applications/mysql.mdx
@@ -7,6 +7,7 @@ color: "#00758f"
 description: Use Filebeat to send MySQL slow query and error logs to your ELK stacks. Configure Filebeat to send MySQL logs to Logstash or Elasticsearch. 
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, Metrics, Database, DB, MySQL, RDBMS, Mysql
 ---
 
 Configure Filebeat to ship logs from MySQL to Logstash and Elasticsearch.

--- a/src/pages/integrations/log-management/applications/network-device.mdx
+++ b/src/pages/integrations/log-management/applications/network-device.mdx
@@ -6,6 +6,7 @@ color: "#1A6C6B"
 description: Send your network device logs to logit.io via logstash using the instructions below and begin searching your data
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, Network, Device, Network Device, Networking, Networkdevice
 ---
 
 Send your network device logs to logit.io via logstash using the instructions below and begin searching your data.

--- a/src/pages/integrations/log-management/applications/nginx.mdx
+++ b/src/pages/integrations/log-management/applications/nginx.mdx
@@ -7,6 +7,7 @@ color: "#00aa4e"
 description: Use Filebeat to send NGINX logs to your ELK stacks. Configure Filebeat to send NGINX logs to Logstash or Elasticsearch.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, Nginx, HTTP, Web Server
 ---
 
 Configure Filebeat to ship logs from a NGINX web server to Logstash and Elasticsearch.

--- a/src/pages/integrations/log-management/applications/openvas.mdx
+++ b/src/pages/integrations/log-management/applications/openvas.mdx
@@ -6,6 +6,7 @@ color: "#71BE45"
 description: Send your OpenVAS reports to logit.io via logstash using the instructions below and begin searching your data
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Vulnerability Assessment, OpenVAS Reports, Security Scan, Openvas
 ---
 
 Send your OpenVAS reports to logit.io via logstash using the instructions below and begin searching your data.

--- a/src/pages/integrations/log-management/applications/ossec.mdx
+++ b/src/pages/integrations/log-management/applications/ossec.mdx
@@ -6,6 +6,7 @@ color: "#E22F29"
 description: Send your OSSEC logs to logit.io via logstash using the instructions below and begin searching your data
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Host Intrusion, HIDS, Detection System, Security, Threat Detection, Intrusion Detection, Ossec
 ---
 
 Send your OSSEC logs to logit.io via logstash using the instructions below and begin searching your data.

--- a/src/pages/integrations/log-management/applications/postgresql.mdx
+++ b/src/pages/integrations/log-management/applications/postgresql.mdx
@@ -6,6 +6,7 @@ color: "#336791"
 description: How to send PostgreSQL logs to your Hosted ELK Logstash instance. Configure Filebeat to send PostgreSQL logs to Logstash or Elasticsearch. 
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, Database, DB, PostgreSQL, RDBMS, SQL, Postgresql
 ---
 
 Filebeat is a lightweight shipper that enables you to send your PostgreSQL 

--- a/src/pages/integrations/log-management/applications/rabbitmq.mdx
+++ b/src/pages/integrations/log-management/applications/rabbitmq.mdx
@@ -7,6 +7,7 @@ color: "#f66000"
 description: Learn how to send RabbitMQ application logs to your Logstash instance - Ship over 100 log data types easily with Logit.io
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, Rabbit, RabbitMQ, Message Queue, Message Broker, AMQP, Rabbitmq, App
 ---
 
 Learn how to send RabbitMQ application logs to your Logstash instance - Ship over 100 log data types easily with Logit.io.

--- a/src/pages/integrations/log-management/applications/redis.mdx
+++ b/src/pages/integrations/log-management/applications/redis.mdx
@@ -6,6 +6,7 @@ color: "#c40d00"
 description: Find the process of sending Redis application logs to your Logstash instance easier through using our provided configuration examples.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, Redis, NoSQL, In-Memory Database, App
 ---
 
 Find the process of sending Redis application logs to your Logstash 

--- a/src/pages/integrations/log-management/applications/sonic-wall.mdx
+++ b/src/pages/integrations/log-management/applications/sonic-wall.mdx
@@ -7,6 +7,7 @@ color: "#f36e21"
 description: How to send SonicWall logs to your Hosted ELK Logstash instance. Configure Filebeat to send data to Logstash. Get started using our example configuration.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, Network Security, Cybersecurity, Sonic, Wall
 ---
 
 Filebeat is a lightweight shipper that enables you to send your SonicWall logs to 

--- a/src/pages/integrations/log-management/applications/stormshield.mdx
+++ b/src/pages/integrations/log-management/applications/stormshield.mdx
@@ -6,6 +6,7 @@ color: "#64D0FF"
 description: Send your Stormshield logs to logit.io via Logstash using the instructions below and begin searching your data
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Storm Shield, SIEM, Cyber-Security, Security, Stormshield
 ---
 
 Ship your Stormshield logs to Logit.io via Logstash.

--- a/src/pages/integrations/log-management/applications/sysmon.mdx
+++ b/src/pages/integrations/log-management/applications/sysmon.mdx
@@ -7,6 +7,7 @@ color: "#00aae5"
 description: Learn how to use Winlogbeat to send Sysmon event logs to your ELK stacks. Configure Winlogbeat to send Sysmon logs to Logstash or Elasticsearch. 
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, System Monitor, Sysmon, Microsoft Sysinternals, Windows Event Logging, Security Monitoring, Windows Event Log, Windows Security, Winlogbeat
 ---
 
 Configure Winlogbeat to ship Sysmon event logs to Logstash and Elasticsearch.

--- a/src/pages/integrations/log-management/applications/traefik.mdx
+++ b/src/pages/integrations/log-management/applications/traefik.mdx
@@ -6,6 +6,7 @@ color: "#qqbfff"
 description: Learn how to send Traefik access logs to your Logstash instance using our configuration examples - Ship over 100 log data types easily with Logit.io
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, Traefik, Web Server, Ingress Controller
 ---
 
 Send Traefik access logs to your Hosted ELK Logstash instance.

--- a/src/pages/integrations/log-management/applications/trend-micro.mdx
+++ b/src/pages/integrations/log-management/applications/trend-micro.mdx
@@ -6,6 +6,7 @@ color: "#D71920"
 description: Send your Trend Micro Secrurity logs to logit.io via logstash using the instructions below and begin searching your data
 stackTypes: logs
 sslPortType: beats-ssl
+tags: TrendMicro, Security, Logs, Antivirus, Trendmicro
 ---
 
 Ship your Trend Micro Security logs to Logit.io via Logstash.

--- a/src/pages/integrations/log-management/aws/aws-cloudwatch-lambda.mdx
+++ b/src/pages/integrations/log-management/aws/aws-cloudwatch-lambda.mdx
@@ -5,6 +5,7 @@ logo: aws-cloudwatch
 color: "#759c3e"
 stackTypes: logs
 description: Push logs from Amazon Cloudwatch to logit.io via the API using the instructions below and begin analysing your data with ELK
+tags: Lambda, Logs, AWS, Amazon, AWS Lambda, Serverless Computing, Aws, Cloudwatch
 ---
 
 <Steps>

--- a/src/pages/integrations/log-management/aws/aws-eks-logs.mdx
+++ b/src/pages/integrations/log-management/aws/aws-eks-logs.mdx
@@ -6,6 +6,7 @@ color: "#ff9900"
 stackTypes: logs
 description: Send your AWS EKS Logs to logit.io via logstash using the instructions below and begin searching your data
 sslPortType: beats-ssl
+tags: Logs, Amazon, AWS, EKS, Container, Kubernetes, Cloud Logs, Aws Eks Logs
 ---
 
 Filebeat is an open source shipping agent that lets you ship AWS 

--- a/src/pages/integrations/log-management/aws/cloudfront.mdx
+++ b/src/pages/integrations/log-management/aws/cloudfront.mdx
@@ -5,6 +5,7 @@ logo: cloudfront
 color: "#f1af00"
 stackTypes: logs
 description: Follow our Amazon Cloudfront tutorial to get started shipping Amazon Cloudfront logs to Logstash for monitoring and analysis in Logit.io.
+tags: Logs, AWS, Amazon, Cloudfront, S3, Cloud Logs
 ---
 
 <Steps>

--- a/src/pages/integrations/log-management/aws/cloudtrail.mdx
+++ b/src/pages/integrations/log-management/aws/cloudtrail.mdx
@@ -5,6 +5,7 @@ logo: cloudtrail
 color: "#689e2f"
 stackTypes: logs
 description: Learn how to send CloudTrail logs to your ELK Logstash instance with our configuration guide. Simplify sending logs with Logit.io's source configurations.
+tags: Logs, AWS, Amazon, Cloudtrail, S3, Cloud Logs
 ---
 
 <Steps>

--- a/src/pages/integrations/log-management/aws/elb-application.mdx
+++ b/src/pages/integrations/log-management/aws/elb-application.mdx
@@ -6,6 +6,7 @@ logo: elbapplicationandclassic
 color: "#ef7c23"
 stackTypes: logs
 description: Use Logit.io's Amazon ELB application logging example configuration to easily forward and send your logs to Logstash and Elasticsearch.
+tags: Logs, Amazon, AWS, Cloud, ELB, Elastic, Load Balancer, S3, Cloud
 ---
 
 <Steps>

--- a/src/pages/integrations/log-management/aws/elb-classic.mdx
+++ b/src/pages/integrations/log-management/aws/elb-classic.mdx
@@ -6,6 +6,7 @@ logo: elbapplicationandclassic
 color: "#ef7c23"
 stackTypes: logs
 description: Learn how to send Amazon ELB logs to your Logstash instance - Ship over 100 log data types fast with Logit.io & simplify your log management.
+tags: Logs, Amazon, AWS, Cloud, ELB, Elastic, Load Balancer, Cloud Logs, Elb Classic
 ---
 
 <Steps>

--- a/src/pages/integrations/log-management/aws/rds.mdx
+++ b/src/pages/integrations/log-management/aws/rds.mdx
@@ -5,6 +5,7 @@ logo: AmazonRDS
 color: "#f1b400"
 stackTypes: logs
 description: Get started with RDS logging with our configuration guide on how to send Amazon RDS logs to your Hosted ELK Logstash instance.
+tags: Logs, RDS, AWS, S3, Database, Cloud Storage, Rds
 ---
 
 <Steps>

--- a/src/pages/integrations/log-management/aws/s3.mdx
+++ b/src/pages/integrations/log-management/aws/s3.mdx
@@ -6,6 +6,7 @@ logo: s3
 color: "#e9463c"
 stackTypes: logs
 description: Send your Amazon S3 application/access/error logs to logit.io via logstash using the instructions below and begin searching your data
+tags: Logs, S3, AWS, Amazon, Cloud Storage
 ---
 
 <Steps>

--- a/src/pages/integrations/log-management/aws/vpc.mdx
+++ b/src/pages/integrations/log-management/aws/vpc.mdx
@@ -6,6 +6,7 @@ logo: vpcflowlogs
 color: "#ef7c23"
 stackTypes: logs
 description: Follow our VPC Flow tutorial to get started sending VPC Flow logs to Logstash for monitoring and analysis in Logit.io.
+tags: Logs, AWS, S3, VPC, Cloud, Vpc
 ---
 
 <Steps>

--- a/src/pages/integrations/log-management/azure/active-directory.mdx
+++ b/src/pages/integrations/log-management/azure/active-directory.mdx
@@ -6,6 +6,7 @@ color: "#2e62a4"
 description: Send your Active Directory Windows Server logs to logit.io via logstash using the instructions below and begin searching your data. 
 stackTypes: logs
 sslPortType: beats-ssl
+tags: AD, Active Directory, Windows, Security, LDAP, Authentication, Winlogbeat
 ---
 
 <Steps>

--- a/src/pages/integrations/log-management/azure/azure-activity-logs.mdx
+++ b/src/pages/integrations/log-management/azure/azure-activity-logs.mdx
@@ -5,6 +5,7 @@ logo: azure
 color: "#0089d6"
 description: Use Logit.io's Azure Activity Log example configuration to easily forward and send your logs to Logstash and Elasticsearch.
 stackTypes: logs
+tags: Microsoft, Azure, Event Hub, Azure Monitoring, Azure Diagnostics, Azure Monitor, Azure Container, Azure Activity Logs, Cloud Monitoring
 ---
 
 In Microsoft Azure the Activity Log is a platform that provides insights into 

--- a/src/pages/integrations/log-management/azure/azure-eventhub-diagnostics.mdx
+++ b/src/pages/integrations/log-management/azure/azure-eventhub-diagnostics.mdx
@@ -5,6 +5,7 @@ logo: azure
 color: "#0089d6"
 description: Follow our Azure Event Hub Diagnostic tutorial to get started shipping Azure Event Hub Diagnostic logs to Logstash for monitoring and analysis.
 stackTypes: logs
+tags: Microsoft, Azure, Event Hub, Cloud Diagnostics, Azure Eventhub Diagnostics
 ---
 
 <Steps>

--- a/src/pages/integrations/log-management/azure/azure-kubernetes-logs.mdx
+++ b/src/pages/integrations/log-management/azure/azure-kubernetes-logs.mdx
@@ -6,6 +6,7 @@ color: "#834c9a"
 description: Follow our Azure Kubernetes Container tutorial to get started shipping logs from Azure Kubernetes Containers to Logstash for monitoring and analysis. 
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, Filebeat, Kubernetes, K8s, AKS, Azure, Azure Kubernetes, Cloud Logs, Azure Kubernetes Logs
 ---
 
 Filebeat is a lightweight shipper that helps you monitor Azure Kubernetes 

--- a/src/pages/integrations/log-management/azure/azure-sql.mdx
+++ b/src/pages/integrations/log-management/azure/azure-sql.mdx
@@ -5,6 +5,7 @@ logo: azure_sql
 color: "#0089d6"
 description: Follow our Azure SQL tutorial to pull logs from Azure Event Hub to Logstash and begin with Azure Application logging.
 stackTypes: logs
+tags: Microsoft, Azure, Event Hub, SQL, Database, Cloud Database, Azure Sql
 ---
 
 <Steps>

--- a/src/pages/integrations/log-management/azure/azure.mdx
+++ b/src/pages/integrations/log-management/azure/azure.mdx
@@ -5,6 +5,7 @@ logo: azure
 color: "#0089d6"
 description: Send your Azure application/access/error logs to logit.io via logstash using the instructions below and begin searching your data
 stackTypes: logs
+tags: Microsoft, Azure, Event Hub, Cloud Services
 ---
 
 Stream Azure monitoring logs to an event hub and configure 

--- a/src/pages/integrations/log-management/containerisation/docker.mdx
+++ b/src/pages/integrations/log-management/containerisation/docker.mdx
@@ -6,6 +6,7 @@ color: "#008bb6"
 description: How to send Docker container application logs to your Hosted ELK Logstash instance. Configure Filebeat to send Docker container logs to your Logit.io Stack.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, Metrics, Docker, Container, Cloud, Kubernetes, Containerization, Microservices, Hub, Cloud Logs
 ---
 
 Filebeat is a lightweight shipper that enables you to send your 

--- a/src/pages/integrations/log-management/containerisation/kubernetes.mdx
+++ b/src/pages/integrations/log-management/containerisation/kubernetes.mdx
@@ -7,6 +7,7 @@ color: "#3a64ad"
 description: Use our example to learn how to send Kubernetes container logs to your Hosted ELK Logstash instance. Configure Filebeat to send data to Logit. 
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, Kubernetes, K8s, GKE, EKS, Cloud
 ---
 
 Filebeat is a lightweight shipper that enables you to send your Kubernetes 

--- a/src/pages/integrations/log-management/containerisation/oracle-kubernetes-engine.mdx
+++ b/src/pages/integrations/log-management/containerisation/oracle-kubernetes-engine.mdx
@@ -6,6 +6,7 @@ color: "#f80000"
 description: How to send Oracle Kubernetes Engine container logs to your Hosted ELK Logstash instance. Configure Filebeat to send data to Logstash. 
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, Kubernetes, K8s, OKE, Oracle, Engine, Cloud, Container Orchestration, Cloud Computing, Containerization, Oracle Kubernetes Engine
 ---
 
 Filebeat is a lightweight shipper that enables you to send your OKE logs to Logstash and Elasticsearch. Configure Filebeat using the pre-defined 

--- a/src/pages/integrations/log-management/containerisation/rancher.mdx
+++ b/src/pages/integrations/log-management/containerisation/rancher.mdx
@@ -6,6 +6,7 @@ color: "#2453ff"
 description: How to send Rancher container application, access or error logs to your Hosted ELK Logstash instance. Logit.io 
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, Rancher, Container, Docker, Container Orchestration, Cloud Native
 ---
 
 Start analysing Rancher logs by following our easy configuration 

--- a/src/pages/integrations/log-management/data-types/json.mdx
+++ b/src/pages/integrations/log-management/data-types/json.mdx
@@ -5,6 +5,7 @@ logo: json
 color: "#e99d00"
 description: Learn how to ship JSON logs to your Hosted Logstash instance using our example configurations. Simplify sending logs with Logit.io's source configurations.
 stackTypes: logs
+tags: Logs, cURL, JSON, HTTP, API, Web Services, Json
 ---
 
 Send JSON logs to Logit.io via Logstash.

--- a/src/pages/integrations/log-management/data-types/upload.mdx
+++ b/src/pages/integrations/log-management/data-types/upload.mdx
@@ -6,6 +6,7 @@ color: "#3a7b84"
 description: How to send file uploads of your logs to your Managed ELK Logstash instance. Simplify sending log data with Logit.io's data source configuration examples.
 stackTypes: logs
 sslPortType: tcp-ssl
+tags: Logs, File, Raw Data, Netcat, Data Upload
 ---
 
 <Steps>

--- a/src/pages/integrations/log-management/firewalls/cisco-firepower.mdx
+++ b/src/pages/integrations/log-management/firewalls/cisco-firepower.mdx
@@ -7,6 +7,7 @@ color: "#336791"
 description: How to send Cisco Firepower logs to your Hosted ELK Logstash instance. Configure Filebeat to send data to Logstash. Get started using our example configuration.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Cisco, Firepower, Firewall, Syslog, Beats, Logs, Filebeat, File, Text, Security Logs, Cisco Firepower
 ---
 
 Filebeat is a lightweight shipper that enables you to send your Cisco Firepower 

--- a/src/pages/integrations/log-management/firewalls/cisco-meraki.mdx
+++ b/src/pages/integrations/log-management/firewalls/cisco-meraki.mdx
@@ -7,6 +7,7 @@ color: "#6AC235"
 description: How to send Cisco Meraki logs to your Hosted ELK Logstash instance. Configure Filebeat to send data to Logstash. Get started using our example configuration.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Cisco, Meraki, Firewall, Syslog, Beats, Logs, Filebeat, File, Text, Security Logs, Cisco Meraki
 ---
 
 Filebeat is a lightweight shipper that enables you to send your Cisco Meraki 

--- a/src/pages/integrations/log-management/firewalls/eset.mdx
+++ b/src/pages/integrations/log-management/firewalls/eset.mdx
@@ -6,6 +6,7 @@ color: "#1A6C6B"
 description: Send your ESET logs to logit.io via logstash using the instructions below and begin searching your data
 stackTypes: logs
 sslPortType: beats-ssl
+tags: ESET, Firewall, SIEM, Cybersecurity, Security, Network Security, Eset
 ---
 
 <Steps>

--- a/src/pages/integrations/log-management/firewalls/fortigate.mdx
+++ b/src/pages/integrations/log-management/firewalls/fortigate.mdx
@@ -7,6 +7,7 @@ color: "#c02607"
 description: Use our example to configure Filebeat to ship Fortigate firewall logs to your Logit.io stacks. Configure Filebeat to send fortigate logs to Logstash or Elastic.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Fortigate, Firewall, Syslog, Beats, Logs, Filebeat, File, Text, Security Logs
 ---
 
 Configure a Fortigate firewall to ship logs via Filebeat to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/log-management/firewalls/junipersrx.mdx
+++ b/src/pages/integrations/log-management/firewalls/junipersrx.mdx
@@ -7,6 +7,7 @@ color: "#e63429"
 description: Use our example to configure Filebeat to ship Juniper SRX firewall logs to Logit.io. Configure Filebeat to send Juniper SRX logs to Logstash or Elastic.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Juniper SRX, Firewall, Syslog, Beats, Logs, Filebeat, Files, Text, Junipersrx
 ---
 
 Configure a Juniper SRX firewall to ship logs via Filebeat to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/log-management/firewalls/palo-alto-networks.mdx
+++ b/src/pages/integrations/log-management/firewalls/palo-alto-networks.mdx
@@ -7,6 +7,7 @@ color: "#e63429"
 description: Use our example to configure Filebeat to ship Palo Alto Networks firewall logs to Logit.io. Configure Filebeat to send Palo Alto logs to Logstash or Elastic.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Palo Alto, Palo Alto Networks, Firewall, Syslog, Beats, Logs, Filebeat, Files, Text, Network Security, Cybersecurity, Palo Alto Networks
 ---
 
 Configure a Palo Alto firewall to ship logs via Filebeat to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/log-management/firewalls/pfsense.mdx
+++ b/src/pages/integrations/log-management/firewalls/pfsense.mdx
@@ -7,6 +7,7 @@ color: "#3c76d7"
 description: Use our example to configure Filebeat to ship pfSense firewall logs to your Logit.io stacks. Configure Filebeat to send Palo Alto logs to Logstash or Elastic.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: pfSense, Firewall, Syslog, Beats, Logs, Filebeat, Files, Text, Network Security, Cybersecurity, Pfsense
 ---
 
 Configure a pfSense firewall to ship logs via Filebeat to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/log-management/google-cloud/compute-engine.mdx
+++ b/src/pages/integrations/log-management/google-cloud/compute-engine.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#205bb0"
 description: Follow our Google Compute Engine tutorial to get started shipping Google Compute Engine logs to Logstash for monitoring and analysis in Logit.io.
 stackTypes: logs
+tags: Logs, Google, GCE, Stack Driver, GKE, Stackdriver, Google Compute Engine, GCP, Cloud Compute, Googlecloudcompute
 ---
 
 <Steps>

--- a/src/pages/integrations/log-management/google-cloud/kubernetes-engine.mdx
+++ b/src/pages/integrations/log-management/google-cloud/kubernetes-engine.mdx
@@ -6,6 +6,7 @@ color: "#3a64ad"
 description: Send your Google Kubernetes Engine Logs to logit.io via logstash using the instructions below and begin searching your data
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, Google, GKE, Container, Kubernetes, Google Kubernetes Engine, Cloud Logs, Google Gke Logs
 ---
 
 Filebeat is an open source shipping agent that lets you ship Google Kubernetes 

--- a/src/pages/integrations/log-management/google-cloud/load-balancing.mdx
+++ b/src/pages/integrations/log-management/google-cloud/load-balancing.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#205bb0"
 description: Follow our configuration and setup example to get started with shipping Google Cloud Load Balancing logs to Lostash for monitoring and analysis in Logit.io. 
 stackTypes: logs
+tags: Logs, Google, GCE, Stack Driver, GKE, Stackdriver, Google Cloud Load Balancing, GCP, Compute, Googlecloudloadbalancing
 ---
 
 Send Google Cloud platform load balancing logs to Logit.io via Logstash.

--- a/src/pages/integrations/log-management/google-cloud/operations.mdx
+++ b/src/pages/integrations/log-management/google-cloud/operations.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#205bb0"
 description: Learn how to send Google Cloud Platform logs to your Logstash instance - Ship over 100 log data types fast with Logit.io & simplify your log analysis.
 stackTypes: logs
+tags: Logs, Google, GCE, Stack Driver, GKE, Stackdriver, Google Cloud Platform, GCP, Google Operations, Cloud Operations, Googlecloudplatform
 ---
 
 <Steps>

--- a/src/pages/integrations/log-management/google-cloud/run.mdx
+++ b/src/pages/integrations/log-management/google-cloud/run.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#205bb0"
 description: Learn how to send Google Cloud Cloud Run logs to your Logstash instance & simplify your log analysis.
 stackTypes: logs
+tags: Logs, Google, GCE, Stack Driver, GKE, Stackdriver, Google Cloud Run, GCP, Cloud Compute, Cloud Run
 ---
 
 <Steps>

--- a/src/pages/integrations/log-management/google-cloud/storage-audit.mdx
+++ b/src/pages/integrations/log-management/google-cloud/storage-audit.mdx
@@ -5,6 +5,7 @@ logo: googlecloud
 color: "#205bb0"
 description: Learn how to send Google Cloud Storage audit logs to your Logstash instance & simplify your log analysis.
 stackTypes: logs
+tags: Logs, Google, GCE, Stack Driver, GKE, Stackdriver, Google Cloud Storage, GCP, GCS, Googlecloudstorage
 ---
 
 <Steps>

--- a/src/pages/integrations/log-management/google-cloud/workspace.mdx
+++ b/src/pages/integrations/log-management/google-cloud/workspace.mdx
@@ -6,6 +6,7 @@ color: "#e63429"
 description: GCP Workspace allows you to send logs to your ELK stacks. Configure GCP Workspace to send logs to Logstash or Elasticsearch. 
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Beats, Logs, GCP Workspace, Google Cloud, Files, Text, Filebeat, Cloud Logs
 ---
 
 Filebeat is an open source shipping agent that lets you ship logs 

--- a/src/pages/integrations/log-management/languages-and-libraries/django.mdx
+++ b/src/pages/integrations/log-management/languages-and-libraries/django.mdx
@@ -7,6 +7,7 @@ color: "#00aa4e"
 stackTypes: logs
 description: Learn how to send Django logs to your Logit.io stack using our configuration examples
 sslPortType: beats-ssl
+tags: Logs, Python, Django, Flask, Scripting, Web Development
 ---
 
 import ConfigurePythonLogstash from "@/components/integrations/partials/configure-python-logstash";

--- a/src/pages/integrations/log-management/languages-and-libraries/dotnet.mdx
+++ b/src/pages/integrations/log-management/languages-and-libraries/dotnet.mdx
@@ -7,6 +7,7 @@ color: "#5c2d91"
 stackTypes: logs
 description: Learn how to ship your dotnet application/access/error logs to Logstash with our example configurations.
 sslPortType: tcp-ssl
+tags: Logs, Microsoft, .NET, Dotnet, Mono, ASP, Application Logs, Microsoft Core, Dotnet Core, ASP, Application Logs, Dotnetcore
 ---
 
 import ConfigureSerilog from "@/components/integrations/partials/configure-serilog";

--- a/src/pages/integrations/log-management/languages-and-libraries/golang.mdx
+++ b/src/pages/integrations/log-management/languages-and-libraries/golang.mdx
@@ -7,6 +7,7 @@ color: "#00b1d1"
 stackTypes: logs
 description: How to send Golang server metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send Go programming language server metrics to Logstash. 
 sslPortType: tcp-ssl
+tags: Logs, Go, Application Logs, Golang
 ---
 
 Configure your GoLang application to send logs to Logstash & Elasticsearch.

--- a/src/pages/integrations/log-management/languages-and-libraries/log4net.mdx
+++ b/src/pages/integrations/log-management/languages-and-libraries/log4net.mdx
@@ -6,6 +6,7 @@ color: "#b20c4c"
 stackTypes: logs
 description: Follow our Log4net tutorial to get started shipping logs from your .net applications to Logstash for monitoring and analysis. 
 portType: tcp
+tags: Logs, Dotnet, .NET, Log4net
 ---
 
 Send your log4net application/access/error logs to Logit.io via Logstash.

--- a/src/pages/integrations/log-management/languages-and-libraries/nlog.mdx
+++ b/src/pages/integrations/log-management/languages-and-libraries/nlog.mdx
@@ -8,6 +8,7 @@ stackTypes: logs
 description: Learn how to send NLog application logs to your Logstash instance - Ship over 100 log data types easily with Logit.io & simplify your log analysis.
 portType: tcp
 sslPortType: tcp-ssl
+tags: Logs, NLog, DotNet, .NET, DotNetCore, Nlog
 ---
 
 Use the Logit.io NLog configuration examples below to 

--- a/src/pages/integrations/log-management/languages-and-libraries/nodejs.mdx
+++ b/src/pages/integrations/log-management/languages-and-libraries/nodejs.mdx
@@ -7,6 +7,7 @@ color: "#82bb26"
 stackTypes: logs
 description: Send your nodejs application/access/error logs to logit.io via Logstash using the instructions below and begin searching your data
 sslPortType: tcp-ssl
+tags: Logs, NodeJS, Node.js, JavaScript, Node, Nodejs
 ---
 
 Get started quickly with NodeJS logging using our configuration 

--- a/src/pages/integrations/log-management/languages-and-libraries/python.mdx
+++ b/src/pages/integrations/log-management/languages-and-libraries/python.mdx
@@ -7,6 +7,7 @@ color: "#0e64a9"
 stackTypes: logs
 description: Learn how to send Python logs to your Logit.io stack using our configuration examples
 sslPortType: beats-ssl
+tags: Logs, Python, Django, Flask, Scripting, Web Development
 ---
 
 Send Python logs to your Logit.io Stack.

--- a/src/pages/integrations/log-management/languages-and-libraries/ruby-on-rails.mdx
+++ b/src/pages/integrations/log-management/languages-and-libraries/ruby-on-rails.mdx
@@ -7,6 +7,7 @@ stackTypes: logs
 description: Get started with Ruby on Rails logging with our configuration guide on how to send Ruby application logs to your Hosted ELK Stack.
 sslPortType: tcp-ssl
 portType: tcp
+tags: Logs, Ruby, Rails, Ruby on Rails, Web Development, On
 ---
 
 This guide was created using `Ruby On Rails (v 2.2)` but you can use any version of ruby that is compatible. 

--- a/src/pages/integrations/log-management/languages-and-libraries/ruby.mdx
+++ b/src/pages/integrations/log-management/languages-and-libraries/ruby.mdx
@@ -8,6 +8,7 @@ stackTypes: logs
 description: Get started quickly with Ruby logging using our configuration guide on how to send Ruby logs to your Hosted ELK Logstash.
 sslPortType: tcp-ssl
 portType: tcp
+tags: Logs, Ruby, Rails, Ruby on Rails, Logstash-Logger, IRB, Scripting, Web Development
 ---
 
 Get started quickly with Ruby logging using our configuration 

--- a/src/pages/integrations/log-management/languages-and-libraries/serilog.mdx
+++ b/src/pages/integrations/log-management/languages-and-libraries/serilog.mdx
@@ -6,6 +6,7 @@ color: "#e63429"
 description: Learn how to ship Serilog application logs to your Hosted ELK Logstash instance using our configuration examples.
 stackTypes: logs
 sslPortType: tcp-ssl
+tags: Logs, .NET, DotNet, Serilog, Logging Framework
 ---
 
 Send Serilog application logs to your Hosted ELK Logstash instance.

--- a/src/pages/integrations/log-management/message-queues/activemq.mdx
+++ b/src/pages/integrations/log-management/message-queues/activemq.mdx
@@ -7,6 +7,7 @@ color: "#d10066"
 description: How to send ActiveMQ message queue logs to your Hosted ELK Logstash instance. Configure Filebeat to send data to logstash.  
 stackTypes: logs
 sslPortType: beats-ssl
+tags: logs, ActiveMQ, queue, message, Queue, Message, JMS, Messaging, Activemq
 ---
 
 Filebeat is a lightweight shipper that enables you to send your ActiveMQ message queue logs to Logstash and Elasticsearch. 

--- a/src/pages/integrations/log-management/message-queues/kafka.mdx
+++ b/src/pages/integrations/log-management/message-queues/kafka.mdx
@@ -6,6 +6,7 @@ color: "#723244"
 description: Use Filebeat to send Kafka MQ topics to your hosted ELK stacks. Configure Filebeat to send Kafka MQ topics to Logstash or Elasticsearch.    
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, Apache Kafka, Kafka MQ, Message Queue
 ---
 
 Filebeat is a lightweight shipper that enables you to send your Apache Kafka message queue logs to Logstash and Elasticsearch. Configure 

--- a/src/pages/integrations/log-management/message-queues/msmq-app.mdx
+++ b/src/pages/integrations/log-management/message-queues/msmq-app.mdx
@@ -5,6 +5,7 @@ logo: msmq
 color: "#008ac2"
 description: Learn how to send MSMQ application logs to your Logstash instance - Ship over 100 log data types fast with Logit.io & simplify your log analysis.
 stackTypes: logs
+tags: Logs, Message Queue, Microsoft, MSMQ, Msmq, App
 ---
 
 Message Queuing (MSMQ) technology enables applications running at different times 

--- a/src/pages/integrations/log-management/open-telemetry/otel-collector-logs.mdx
+++ b/src/pages/integrations/log-management/open-telemetry/otel-collector-logs.mdx
@@ -6,6 +6,7 @@ color: "#2e62a4"
 description: The OpenTelemetry Collector sends logs, metrics, and traces to your ELK stacks. Configure OTEL Collector to send data and events to Logstash and Elasticsearch.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: OTEL, OTEL Collector, OpenTelemetry, Logs, Telemetry
 ---
 
 The OpenTelemetry Collector allows you to send logs to your Logit.io stacks.

--- a/src/pages/integrations/log-management/operating-systems/centos.mdx
+++ b/src/pages/integrations/log-management/operating-systems/centos.mdx
@@ -7,6 +7,7 @@ color: "#001a52"
 description: Use Filebeat to send Centos logs to your ELK stacks. Configure Filebeat to send Centos application logs to Logstash or Elasticsearch. 
 stackTypes: logs
 sslPortType: beats-ssl
+tags: logs, centos, linux, Centos
 ---
 
 Configure Filebeat to ship logs from Centos Systems to Logstash and Elasticsearch.

--- a/src/pages/integrations/log-management/operating-systems/debian.mdx
+++ b/src/pages/integrations/log-management/operating-systems/debian.mdx
@@ -6,6 +6,7 @@ color: "#a80030"
 description: Use Filebeat to send Debian application, access and system logs to your ELK stacks. Configure Filebeat to send Debian system logs to Logstash or Elasticsearch.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, Debian, Linux, Operating System Logs
 ---
 
 Configure Filebeat to ship logs from Debian Systems to Logstash and Elasticsearch.

--- a/src/pages/integrations/log-management/operating-systems/filebeat-system.mdx
+++ b/src/pages/integrations/log-management/operating-systems/filebeat-system.mdx
@@ -6,6 +6,7 @@ color: "#0c6c6b"
 description: Filebeat allows you to send system logs to your ELK stacks. Configure Filebeat to send system logs to Logstash or Elasticsearch.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Beats, Logs, Filebeat, System, Syslog, Auth, Authentication Logs, Filebeat System
 ---
 
 Filebeat is an open source shipping agent that lets you ship logs from local files to one or more destinations, including Logstash.

--- a/src/pages/integrations/log-management/operating-systems/macos.mdx
+++ b/src/pages/integrations/log-management/operating-systems/macos.mdx
@@ -7,6 +7,7 @@ color: "#3c76d7"
 description: Use Filebeat to send macOS logs to your ELK stacks. Configure Filebeat to send macOS system logs to Logstash or Elasticsearch.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, Mac, Apple, OSX, Mojave, MacOS, Macos
 ---
 
 Configure Filebeat to ship logs from macOS Systems to Logstash and Elasticsearch.

--- a/src/pages/integrations/log-management/operating-systems/redhat.mdx
+++ b/src/pages/integrations/log-management/operating-systems/redhat.mdx
@@ -7,6 +7,7 @@ color: "#ee0000"
 description: Use Filebeat to send Red Hat application, access and system logs to your ELK stacks. Configure Filebeat to send Red Hat system logs to Elasticsearch. 
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, RedHat, Red Hat, RHEL, Fedora, Linux Distribution, Redhat
 ---
 
 Configure Filebeat to ship logs from Red Hat Systems to Logstash and Elasticsearch.

--- a/src/pages/integrations/log-management/operating-systems/solaris.mdx
+++ b/src/pages/integrations/log-management/operating-systems/solaris.mdx
@@ -7,6 +7,7 @@ color: "#c74634"
 description: Follow our installation guide for Oracle Solaris logs to get started centralising your data using the Elastic Stack.
 stackTypes: logs
 sslPortType: syslog-ssl
+tags: Logs, Solaris, Sun, Oracle, Syslog, Unix
 ---
 
 Configure syslog to ship logs from Solaris Systems to Logstash.

--- a/src/pages/integrations/log-management/operating-systems/ubuntu.mdx
+++ b/src/pages/integrations/log-management/operating-systems/ubuntu.mdx
@@ -7,6 +7,7 @@ color: "#e95521"
 description: Follow our configuration guide to send Ubuntu system logs and get started centralising your data using the Elastic Stack.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, Ubuntu, System, Linux, Operating System
 ---
 
 Configure Filebeat to ship logs from Ubuntu Systems to Logstash and Elasticsearch.

--- a/src/pages/integrations/log-management/operating-systems/windows.mdx
+++ b/src/pages/integrations/log-management/operating-systems/windows.mdx
@@ -7,6 +7,7 @@ color: "#00bfb3"
 description: Send your Windows application/access/error logs to your Logstash instance via Winlogbeat. Simplify sending logs with Logit.io's data source configurations.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, Windows, Microsoft, System, Event Log, Operating System, Winlogbeat
 ---
 
 Winlogbeat is a Windows specific event-log shipping agent installed 

--- a/src/pages/integrations/log-management/platforms/appharbor.mdx
+++ b/src/pages/integrations/log-management/platforms/appharbor.mdx
@@ -5,6 +5,7 @@ logo: appharbor
 color: "#2b4e6e"
 description: Send your AppHarbor access/error logs to logit.io via logstash using the instructions below and begin searching your data
 stackTypes: logs
+tags: Logs, AppHarbor, .NET, PaaS, Platform as a Service, Application Hosting, Appharbor
 ---
 
 Send your AppHarbor access/error logs to logit.io via logstash using the instructions below and begin searching your data

--- a/src/pages/integrations/log-management/platforms/bunny-net.mdx
+++ b/src/pages/integrations/log-management/platforms/bunny-net.mdx
@@ -6,6 +6,7 @@ color: "#ff9900"
 description: Use our example to configure Filebeat to ship bunny.net content delivery logs to your Logit.io stacks. Configure Filebeat to send bunny.net logs to Logstash or Elastic.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: bunny.net, bunny.net content delivery, content delivery network, cdn, syslog, beats, logs, filebeat, file ,files, text, Bunny Net
 ---
 
 Configure a bunny.net to ship logs via Filebeat to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/log-management/platforms/checkpoint.mdx
+++ b/src/pages/integrations/log-management/platforms/checkpoint.mdx
@@ -5,6 +5,7 @@ logo: checkpoint
 color: "#E0005A"
 description: Follow our Checkpoint tutorial to get started sending Checkpoint logs to Logstash for monitoring and analysis.
 stackTypes: logs
+tags: Logs, Checkpoint, Firewall, Security Logs
 ---
 
 Follow our Checkpoint tutorial to get started sending Checkpoint logs to Logstash for monitoring and analysis.

--- a/src/pages/integrations/log-management/platforms/cloudfoundry.mdx
+++ b/src/pages/integrations/log-management/platforms/cloudfoundry.mdx
@@ -7,6 +7,7 @@ description: Learn how to streamline your logging process by shipping Cloud Foun
 stackTypes: logs
 portType: tcp
 sslPortType: tcp-ssl
+tags: Logs, Cloud Foundry, Cloudfoundry, VMware, VMware Tanzu, BOSH, Pivotal, Log Drain, Cloud Logs
 ---
 
 import SetupLogDrain from "@/components/integrations/partials/cloudfoundry/setup-log-drain";

--- a/src/pages/integrations/log-management/platforms/digital-ocean.mdx
+++ b/src/pages/integrations/log-management/platforms/digital-ocean.mdx
@@ -7,6 +7,7 @@ color: "#0080FF"
 description: Learn how to forward logs from your DigitalOcean droplets and Kubernetes clusters to Logit.io via Logstash. Use this guide to set up log forwarding to Logit.io.
 stackTypes: logs
 sslPortType: Syslog-SSL
+tags: DigitalOcean, Logs, Syslog, Centralized Logging, Kubernetes, Droplets, Cloud Computing, Monitoring
 ---
 
 Learn how to forward logs from your DigitalOcean droplets and Kubernetes clusters to Logit.io via Logstash.

--- a/src/pages/integrations/log-management/platforms/fail2ban.mdx
+++ b/src/pages/integrations/log-management/platforms/fail2ban.mdx
@@ -5,6 +5,7 @@ color: "#e63429"
 description: Use our example to configure Filebeat to ship Fail2ban logs to your Logit.io stacks. Configure Filebeat to send Fail2ban logs to Logstash or Elastic.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Fail2ban, OSSEC, Security, Monitoring, Threat Detection, Beats, Logs, Filebeat, File, Text, Log Files
 ---
 
 Configure Fail2ban to ship logs via Filebeat to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/log-management/platforms/falco.mdx
+++ b/src/pages/integrations/log-management/platforms/falco.mdx
@@ -6,6 +6,7 @@ color: "#19c5b9"
 description: Use our example to configure Filebeat to ship Falco logs to your Logit.io stacks. Configure Filebeat to send Falco logs to Logstash or Elastic.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Falco, IDS, Threat Detection, Kubernetes, Syslog, Beats, Logs, Filebeat, File, Text, Log Files
 ---
 
 Configure Falco to ship logs via Filebeat to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/log-management/platforms/fastly.mdx
+++ b/src/pages/integrations/log-management/platforms/fastly.mdx
@@ -6,6 +6,7 @@ color: "#e31e1c"
 description: Send your Fastly application/access/error logs to logit.io via logstash using the instructions below and begin searching your data
 stackTypes: logs
 sslPortType: syslog-ssl
+tags: Logs, Fastly
 ---
 
 Send your Fastly application/access/error logs to logit.io via logstash 

--- a/src/pages/integrations/log-management/platforms/gitlabs.mdx
+++ b/src/pages/integrations/log-management/platforms/gitlabs.mdx
@@ -6,6 +6,7 @@ color: "#f66000"
 description: Use our example to configure Filebeat to ship GitLab logs to your Logit.io stacks. Configure Filebeat to send GitLab logs to Logstash or Elastic.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: GitLab, DevOps, Syslog, Beats, Logs, Filebeat, File, Text, Log Files, Gitlabs
 ---
 
 Configure GitLab to ship logs via Filebeat to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/log-management/platforms/heroku.mdx
+++ b/src/pages/integrations/log-management/platforms/heroku.mdx
@@ -6,6 +6,7 @@ logo: heroku
 color: "#713cb1"
 description: Follow our Heroku tutorial to get started sending Heroku logs to Logstash for monitoring and analysis.
 stackTypes: logs
+tags: Logs, Heroku, Cloud, Ruby, PaaS, Platform as a Service
 ---
 
 Follow our Heroku tutorial to get started sending Heroku logs to Logstash for monitoring and analysis.

--- a/src/pages/integrations/log-management/platforms/keycdn.mdx
+++ b/src/pages/integrations/log-management/platforms/keycdn.mdx
@@ -6,6 +6,7 @@ color: "#047aed"
 description: Learn how to ship KeyCDN logs to your Hosted ELK Logstash instance using our example configurations.
 stackTypes: logs
 portType: syslog
+tags: Logs, KeyCDN, CDN, Content Delivery Network, Keycdn
 ---
 
 import ConfigureKeyCdn from "@/components/integrations/partials/configure-key-cdn";

--- a/src/pages/integrations/log-management/platforms/microsoft365.mdx
+++ b/src/pages/integrations/log-management/platforms/microsoft365.mdx
@@ -6,6 +6,7 @@ color: "#2e62a4"
 description: Use our example to configure Filebeat to ship Microsoft 365 logs to your Logit.io stacks. Configure Filebeat to send Microsoft 365 logs to Logstash or Elastic.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: M365, O365, Microsoft, Microsoft 365, Syslog, Beats, Logs, Filebeat, Files, Text, Microsoft365
 ---
 
 Configure Microsoft 365 to ship logs via Filebeat to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/log-management/platforms/openvpn.mdx
+++ b/src/pages/integrations/log-management/platforms/openvpn.mdx
@@ -6,6 +6,7 @@ color: "#ea610a"
 description: Use our example to configure Filebeat to ship OpenVPN logs to your Logit.io stacks. Configure Filebeat to send OpenVPN logs to Logstash or Elastic.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: OpenVPN, Open VPN, Syslog, Beats, Logs, Filebeat, Files, Text, Virtual Private Network, Encryption, Network Security, Openvpn
 ---
 
 Configure OpenVPN to ship logs via Filebeat to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/log-management/platforms/sentinelone.mdx
+++ b/src/pages/integrations/log-management/platforms/sentinelone.mdx
@@ -6,6 +6,7 @@ color: "#713cb1"
 description: Send your SentinelOne logs to logit.io via logstash using the instructions below and begin searching your data
 stackTypes: logs
 sslPortType: beats-ssl
+tags: SentinelOne, Sentinel One, SIEM, Cyber-Security, Security, Network, Endpoint Security, Sentinelone
 ---
 
 Send your SentinelOne logs to logit.io via logstash using the instructions below and begin searching your data

--- a/src/pages/integrations/log-management/platforms/wazuh.mdx
+++ b/src/pages/integrations/log-management/platforms/wazuh.mdx
@@ -6,6 +6,7 @@ color: "#e63429"
 description: Use our example to configure Filebeat to ship Wazuh logs to your Logit.io stacks. Configure Filebeat to send Wazuh logs to Logstash or Elastic.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Wazuh, OSSEC, Firewall, Syslog, Beats, Logs, Filebeat, Text Logs
 ---
 
 Configure Wazuh to ship logs via Filebeat to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/log-management/platforms/zeek.mdx
+++ b/src/pages/integrations/log-management/platforms/zeek.mdx
@@ -5,6 +5,7 @@ color: "#008bb6"
 description: Use our example to configure Filebeat to ship Zeek logs to your Logit.io stacks. Configure Filebeat to send Zeek logs to Logstash or Elastic.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Zeek, Open Source, Firewall, Network Analysis, Security, Logs, Filebeat, Text Logs
 ---
 
 Configure Zeek to ship logs via Filebeat to your Logit.io stacks via Logstash.

--- a/src/pages/integrations/log-management/protocols/gelf.mdx
+++ b/src/pages/integrations/log-management/protocols/gelf.mdx
@@ -6,6 +6,7 @@ logo: gelf
 description: Learn how to send Gelf logs to your Logstash instance & Elastic Stack - Ship over 100 log data types fast with Logit.io & simplify your log analysis.
 stackTypes: logs
 portType: gelf
+tags: Logs, GELF, Logstash, Log Files, Gelf
 ---
 
 Configure Gelf logs to automatically send to Logstash and Elasticsearch 

--- a/src/pages/integrations/log-management/protocols/http.mdx
+++ b/src/pages/integrations/log-management/protocols/http.mdx
@@ -5,6 +5,7 @@ logo: https
 color: "#30a743"
 description: How to send HTTP endpoint server metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send HTTP endpoint server metrics to Elasticsearch.
 stackTypes: logs
+tags: Logs, HTTP, JSON, API, cURL, Http, Curl, CURL
 ---
 
 Send HTTP/S logs to your Logit.io Stack via Logstash.

--- a/src/pages/integrations/log-management/protocols/syslog-ng.mdx
+++ b/src/pages/integrations/log-management/protocols/syslog-ng.mdx
@@ -7,6 +7,7 @@ description: Follow our configuration guide for Syslog-ng-ng logs to get started
 stackTypes: logs
 sslPortType: syslog-ssl
 portType: syslog
+tags: Logs, Rsyslog, Linux, Syslogd, Logging, Syslog Ng
 ---
 
 Learn how configure syslog-ng to securely ship logs over SSL to your 

--- a/src/pages/integrations/log-management/protocols/syslog.mdx
+++ b/src/pages/integrations/log-management/protocols/syslog.mdx
@@ -7,6 +7,7 @@ description: Follow our configuration guide for Syslog logs to get started centr
 stackTypes: logs
 sslPortType: syslog-ssl
 portType: syslog
+tags: Logs, Syslog, Rsyslog, Linux, Syslogd, Logging
 ---
 
 Send HTTP/S logs to your Logit.io Stack via Logstash.Learn how configure 

--- a/src/pages/integrations/log-management/protocols/tcp.mdx
+++ b/src/pages/integrations/log-management/protocols/tcp.mdx
@@ -7,6 +7,7 @@ description: Learn how to send TCP logs to your Logstash instance using our conf
 stackTypes: logs
 sslPortType: tcp-ssl
 portType: tcp
+tags: Logs, TCP, SSL, TLS, Netcat, Networking, Security, Encryption, Network Protocol, Tcp
 ---
 
 <Steps>

--- a/src/pages/integrations/log-management/protocols/udp.mdx
+++ b/src/pages/integrations/log-management/protocols/udp.mdx
@@ -6,6 +6,7 @@ color: "#2b7014"
 description: Learn how to send UDP logs to your Logstash instance using our configuration examples - Ship over 100 log data types easily with Logit.io
 stackTypes: logs
 portType: tcp
+tags: Logs, UDP, Network, Protocol, Udp
 ---
 
 <Steps>

--- a/src/pages/integrations/log-management/shippers/auditbeat.mdx
+++ b/src/pages/integrations/log-management/shippers/auditbeat.mdx
@@ -6,6 +6,7 @@ color: "#19c5b9"
 description: Send UDP logs to your Logit.io using our example. Auditbeat is an open-source shipping agent that lets you ship audit data to Logstash & Elasticsearch (ELK).
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Beats, Logs, Audit, Auditing, Security Logs, Auditbeat
 ---
 
 Auditbeat is an open source shipping agent that lets you ship 

--- a/src/pages/integrations/log-management/shippers/aws-beanstalk.mdx
+++ b/src/pages/integrations/log-management/shippers/aws-beanstalk.mdx
@@ -7,6 +7,7 @@ color: "#00aa4e"
 description: Filebeat allows you to send logs to your ELK stacks. Configure Filebeat to send logs to Logstash or Elasticsearch.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Beats, Logs, AWS Beanstalk, File, Files, Text, Log Files
 ---
 
 Filebeat is an open source shipping agent that lets you ship 

--- a/src/pages/integrations/log-management/shippers/elastic-agent.mdx
+++ b/src/pages/integrations/log-management/shippers/elastic-agent.mdx
@@ -7,6 +7,7 @@ color: "#00bfb3"
 description: Elastic Agent allows you to send logs, metrics, and diverse data types to stacks. Configure Elastic Agent to send logs to Logstash or Elasticsearch.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Beats, Logs, Elastic Agent, Files, Text, Log Files, Elastic Agent
 ---
 
 Elastic Agent offers a unified approach for seamlessly incorporating monitoring of logs, 

--- a/src/pages/integrations/log-management/shippers/elasticsearch.mdx
+++ b/src/pages/integrations/log-management/shippers/elasticsearch.mdx
@@ -6,6 +6,7 @@ color: "#5da4dc"
 description: Filebeat allows you to send logs to your ELK stacks. Configure Filebeat to send Elasticsearch logs to Logstash and Elasticsearch.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, Logstash, Elasticsearch, Beats, Filebeat, Files, Log Files
 ---
 
 Filebeat is an open source shipping agent that lets you ship logs from 

--- a/src/pages/integrations/log-management/shippers/filebeat.mdx
+++ b/src/pages/integrations/log-management/shippers/filebeat.mdx
@@ -7,6 +7,7 @@ color: "#00bfb3"
 description: Filebeat allows you to send logs to your ELK stacks. Configure Filebeat to send logs to Logstash or Elasticsearch. 
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Beats, Logs, Filebeat, File, Files, Text, Log Files
 ---
 
 Filebeat is an open source shipping agent that lets you ship 

--- a/src/pages/integrations/log-management/shippers/fluent-bit.mdx
+++ b/src/pages/integrations/log-management/shippers/fluent-bit.mdx
@@ -7,6 +7,7 @@ description: Fluent Bit allows you to send logs to your ELK stacks. Configure Fl
 stackTypes: logs
 sslPortType: tcp-ssl
 portType: tcp
+tags: Logs, Fluent, Fluentbit, Kubernetes, Container Logs, Fluent Bit
 ---
 
 Fluent Bit is an open source data collector which can be used to 

--- a/src/pages/integrations/log-management/shippers/fluentd.mdx
+++ b/src/pages/integrations/log-management/shippers/fluentd.mdx
@@ -6,6 +6,7 @@ color: "#2e62a4"
 description: Follow our Fluentd tutorial to get started shipping logs from Fluentd events to Logstash for monitoring and analysis in Logit.io.
 stackTypes: logs
 sslPortType: tcp-ssl
+tags: Logs, Fluent, Fluentd, Ruby, Application Logs
 ---
 
 Fluentd is an open source data collector which can be used to collect event logs from multiple sources. 

--- a/src/pages/integrations/log-management/shippers/heartbeat.mdx
+++ b/src/pages/integrations/log-management/shippers/heartbeat.mdx
@@ -7,6 +7,7 @@ color: "#00bfb3"
 description: Get started with sending your log data from Heartbeat to Logstash using our simple integration guide below.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Beats, Logs, Monitoring, Healthcheck, Heartbeat
 ---
 
 Heartbeat is a lightweight shipping agent used to monitor the health of services running on the host. 

--- a/src/pages/integrations/log-management/shippers/journalbeat.mdx
+++ b/src/pages/integrations/log-management/shippers/journalbeat.mdx
@@ -7,6 +7,7 @@ color: "#00bfb3"
 description: Journalbeat allows you to send log data from systemd journals stored on Linux operating systems to your ELK stacks.  
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Beats, Logs, Journalbeat, Journals, Systemd, Linux, System
 ---
 
 Journalbeat is a lightweight, open source shipping agent that lets you ship log data from systemd journals stored on Linux operating systems to one or more destinations, including Logstash.

--- a/src/pages/integrations/log-management/shippers/kibana.mdx
+++ b/src/pages/integrations/log-management/shippers/kibana.mdx
@@ -7,6 +7,7 @@ color: "#d7689d"
 description: Filebeat allows you to send logs to your ELK stacks. Configure Filebeat to send Kibana logs to Logstash and Elasticsearch.  
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, Logstash, Elasticsearch, Beats, Filebeat, File, Kibana
 ---
 
 Filebeat is an open source shipping agent that lets you ship logs from local files to one or more destinations, 

--- a/src/pages/integrations/log-management/shippers/logstash-logging.mdx
+++ b/src/pages/integrations/log-management/shippers/logstash-logging.mdx
@@ -7,6 +7,7 @@ color: "#f3b800"
 description: Filebeat allows you to send logs to your ELK stacks. Configure Filebeat to send Logstash logs to Elasticsearch.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Logs, Logstash, Elasticsearch, Beats, Filebeat, File, Logging
 ---
 
 Filebeat is an open source shipping agent that lets you ship logs from local files to one or more destinations, including Logstash.

--- a/src/pages/integrations/log-management/shippers/logstash.mdx
+++ b/src/pages/integrations/log-management/shippers/logstash.mdx
@@ -7,6 +7,7 @@ color: "#f3b800"
 description: Learn how to get started with logging and send data from your local Logstash to your Hosted ELK instance with this configuration example.
 stackTypes: logs
 sslPortType: tcp-ssl
+tags: Logs, Metrics, Logstash, Elasticsearch, JSON
 ---
 
 All Logit.io ELK Stacks include highly available hosted Logstash instances, removing the need for installing and maintaining your own 

--- a/src/pages/integrations/log-management/shippers/metricbeat.mdx
+++ b/src/pages/integrations/log-management/shippers/metricbeat.mdx
@@ -7,6 +7,7 @@ color: "#00bfb3"
 description: Use Logit.io's Metricbeat example configuration to easily forward and send your logs to Logstash and Elasticsearch.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Beats, Logs, Metrics, Metricbeat, Stats, System, Monitoring
 ---
 
 Metricbeat is an open-source shipping agent used to collect and ship 

--- a/src/pages/integrations/log-management/shippers/packetbeat.mdx
+++ b/src/pages/integrations/log-management/shippers/packetbeat.mdx
@@ -7,6 +7,7 @@ color: "#009f95"
 description: Packetbeat setup and example configuration for sending logs to the Elastic Stack. Simplify sending logs with Logit.io's data source config examples and guides.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Beats, Logs, Network, Packet, Traffic, Network Monitoring, Network Analysis, Packet Capture, Packetbeat
 ---
 
 Packetbeat is a network package analyser used to capture network traffic. It can be used to extract useful fields of information from network transactions 

--- a/src/pages/integrations/log-management/shippers/winlogbeat.mdx
+++ b/src/pages/integrations/log-management/shippers/winlogbeat.mdx
@@ -7,6 +7,7 @@ color: "#00bfb3"
 description: Winlogbeat is a Windows specific event-log shipping agent. It can be used to collect and send event logs to one or more destinations.
 stackTypes: logs
 sslPortType: beats-ssl
+tags: Beats, Logs, Windows, Microsoft, System, Event Log, Logging, Winlogbeat
 ---
 
 Winlogbeat is a Windows specific event-log shipping agent installed as a Windows service. It can be used to collect and send 

--- a/src/pages/integrations/observability/otel-collector.mdx
+++ b/src/pages/integrations/observability/otel-collector.mdx
@@ -6,6 +6,7 @@ color: "#2e62a4"
 description: The OpenTelemetry Collector allows you to send logs, metrics and traces to your ELK stacks. Configure OTEL Collector to send data to Logstash and Elasticsearch.
 stackTypes: logs, metrics, apm
 sslPortType: beats-ssl
+tags: OTEL, OTEL Collector, OpenTelemetry, Logs, Metrics, Traces, Telemetry
 ---
 
 The OpenTelemetry Collector allows you to send logs, metrics and traces to your Logit.io stacks.


### PR DESCRIPTION
https://logitio.monday.com/boards/806674751/pulses/7607189111

This PR is to add the tags back to the source integrations. They will be getting used in future for the filter on the integrations.

There is also another PR that adds the "tags" as a global property so that they can be accessed, this is here:
https://github.com/logit-io/docs/pull/95
