### PR TITLE
Update metricbeat stack type

### DIFF
--- a/src/pages/integrations/infrastructure-metrics/applications/mongodb-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/applications/mongodb-metrics.mdx
@@ -5,7 +5,7 @@ subTitle: Collect and ship MongoDB server metrics to Logstash and Elasticsearch
 logo: mongodb
 color: "#419544"
 description: How to send MongoDB server metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send MongoDB database server metrics to Logstash. 
-stackTypes: metrics
+stackTypes: logs
 sslPortType: beats-ssl
 tags: Metrics, Metricbeat, Stats, Database, MongoDB, NoSQL, Module, Mongodb
 ---

--- a/src/pages/integrations/infrastructure-metrics/applications/mysql-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/applications/mysql-metrics.mdx
@@ -5,7 +5,7 @@ subTitle: Collect and ship MySql metrics to Logstash and Elasticsearch
 logo: mysql
 color: "#00758f"
 description: How to send MySql database server metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send MySql server metrics to Logstash or Elasticsearch. 
-stackTypes: metrics
+stackTypes: logs
 sslPortType: beats-ssl
 tags: Metrics, Metricbeat, Stats, MySQL, Database, Module, Mysql
 ---

--- a/src/pages/integrations/infrastructure-metrics/applications/postgresql-metrics.mdx
+++ b/src/pages/integrations/infrastructure-metrics/applications/postgresql-metrics.mdx
@@ -4,7 +4,7 @@ subTitle: Collect and ship PostgreSQL metrics to Logstash and Elasticsearch
 logo: postgresqlelephant
 color: "#336791"
 description: How to send PostgreSQL database server metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send PostgreSQL server metrics to Logstash.
-stackTypes: metrics
+stackTypes: logs
 sslPortType: beats-ssl
 tags: Database, DB, PostgreSQL, RDBMS, Metricset, Module, Postgresql
 ---

--- a/src/pages/integrations/infrastructure-metrics/languages-and-libraries/metricbeat-module-golang.mdx
+++ b/src/pages/integrations/infrastructure-metrics/languages-and-libraries/metricbeat-module-golang.mdx
@@ -5,7 +5,7 @@ subTitle: Collect and ship Golang server metrics to Logstash and Elasticsearch
 logo: golang
 color: "#00b1d1"
 description: How to send Golang server metrics to your Hosted ELK Logstash instance. Get started using our Metricbeat Golang server module example configurations.
-stackTypes: metrics
+stackTypes: logs
 sslPortType: beats-ssl
 tags: GoLang, Go, GoMetrics, Metricbeat, Monitoring, Performance, Instrumentation, Metrics Collection, Observability, Logs, Log Analysis, DevOps, System Metrics, Application Metrics, Module, Golang
 ---

--- a/src/pages/integrations/infrastructure-metrics/message-queues/metricbeat-module-rabbitmq.mdx
+++ b/src/pages/integrations/infrastructure-metrics/message-queues/metricbeat-module-rabbitmq.mdx
@@ -5,7 +5,7 @@ subTitle: Collect and ship RabbitMQ service metrics to Logstash and Elasticsearc
 logo: rabbitmq
 color: "#f66000"
 description: How to send RabbitMQ message queue metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send RabbitMQ metrics to Logstash or Elasticsearch.
-stackTypes: metrics
+stackTypes: logs
 sslPortType: beats-ssl
 tags: Metrics, Metricbeat, Stats, RabbitMQ, Message Queue, Module, Rabbitmq
 ---

--- a/src/pages/integrations/infrastructure-metrics/message-queues/metricbeat-module-redis.mdx
+++ b/src/pages/integrations/infrastructure-metrics/message-queues/metricbeat-module-redis.mdx
@@ -5,7 +5,7 @@ subTitle: Collect and ship Redis server metrics to Logstash and Elasticsearch
 logo: redis
 color: "#c40d00"
 description: How to send Redis server metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send Redis server metrics to Logstash or Elasticsearch.
-stackTypes: metrics
+stackTypes: logs
 sslPortType: beats-ssl
 tags: Metrics, Metricbeat, Stats, Redis, Module
 ---

--- a/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-system-centos.mdx
+++ b/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-system-centos.mdx
@@ -5,7 +5,7 @@ subTitle: Collect and ship CentOS operating system and service metrics to Logsta
 logo: centos
 color: "#001a52"
 description: Sending System Metrics from CentOS to Your Hosted ELK Logstash Instance - Configuring Metricbeat for Transmission to Logstash or Elasticsearch.
-stackTypes: metrics
+stackTypes: logs
 sslPortType: beats-ssl
 tags: Metrics, Metricbeat, Stats, System, CentOS, Module, Centos
 ---

--- a/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-system-debian.mdx
+++ b/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-system-debian.mdx
@@ -5,7 +5,7 @@ subTitle: Collect and ship Debian operating system and service metrics to Logsta
 logo: debian
 color: "#a80030"
 description: How to send Debian System metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send Debian System metrics to Logstash or Elasticsearch.
-stackTypes: metrics
+stackTypes: logs
 sslPortType: beats-ssl
 tags: Metrics, Metricbeat, Stats, System, Debian, Module
 ---

--- a/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-system-macos.mdx
+++ b/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-system-macos.mdx
@@ -5,7 +5,7 @@ subTitle: Collect and ship macOS operating system and service metrics to Logstas
 logo: macos
 color: "#3c76d7"
 description: How to send macOS System metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send macOS System metrics to Logstash or Elasticsearch.
-stackTypes: metrics
+stackTypes: logs
 sslPortType: beats-ssl
 tags: Metrics, Metricbeat, Stats, System, MacOS, Apple, OSX, Mojave, Operating System Monitor, Module, Macos
 ---

--- a/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-system-redhat.mdx
+++ b/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-system-redhat.mdx
@@ -6,7 +6,7 @@ subTitle: Collect and ship Red Hat Enterprise Linux (RHEL) operating system and 
 logo: redhat
 color: "#ee0000"
 description: Transmitting Red Hat (RHEL) System Metrics to Your Hosted ELK Logstash Instance - Configuring Metricbeat to Send Red Hat Metrics to Logstash or Elasticsearch.
-stackTypes: metrics
+stackTypes: logs
 sslPortType: beats-ssl
 tags: Metrics, Metricbeat, Stats, System, RedHat, Red Hat, RHEL, Fedora, Operating System Monitor, Module, Redhat
 ---

--- a/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-system-ubuntu.mdx
+++ b/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-system-ubuntu.mdx
@@ -5,7 +5,7 @@ subTitle: Collect and ship Ubuntu operating system and service metrics to Logsta
 logo: ubuntu
 color: "#e95521"
 description: Sending Ubuntu System Metrics to Your Hosted ELK Logstash Instance - Configuring Metricbeat for Transmitting System Metrics to Logstash or Elasticsearch.
-stackTypes: metrics
+stackTypes: logs
 sslPortType: beats-ssl
 tags: Metrics, Metricbeat, Stats, System, Ubuntu, Operating System Monitor, Module
 ---

--- a/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-system-windows.mdx
+++ b/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-system-windows.mdx
@@ -5,7 +5,7 @@ subTitle: Collect and ship Windows operating system and service metrics to Logst
 logo: windows
 color: "#00aae5"
 description: How to send Windows System metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send Windows System metrics to Logstash or Elasticsearch. 
-stackTypes: metrics
+stackTypes: logs
 sslPortType: beats-ssl
 tags: Metrics, Metricbeat, Stats, System, Microsoft, Windows, Operating System Monitor, Module
 ---

--- a/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-uwsgi.mdx
+++ b/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-uwsgi.mdx
@@ -5,7 +5,7 @@ subTitle: Collect and ship uWSGI server metrics to Logstash and Elasticsearch
 logo: uwsgi
 color: "#93b20f"
 description: How to send uWSGI metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send uWSGI server metrics to Logstash or Elasticsearch.
-stackTypes: metrics
+stackTypes: logs
 sslPortType: beats-ssl
 tags: Metrics, Metricbeat, Stats, uWSGI, Application Server, Module, Uwsgi
 ---

--- a/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-windows.mdx
+++ b/src/pages/integrations/infrastructure-metrics/operating-systems/metricbeat-module-windows.mdx
@@ -5,7 +5,7 @@ subTitle: Collect and ship Windows services & performance counter metrics to Log
 logo: windows
 color: "#00aae5"
 description: How to send Windows services & performance counter metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send Windows metrics to Logstash.
-stackTypes: metrics
+stackTypes: logs
 sslPortType: beats-ssl
 tags: Metrics, Metricbeat, Stats, System, Microsoft, Windows, Operating System Monitor, Module
 ---

--- a/src/pages/integrations/infrastructure-metrics/platforms/metricbeat-module-apache.mdx
+++ b/src/pages/integrations/infrastructure-metrics/platforms/metricbeat-module-apache.mdx
@@ -5,7 +5,7 @@ subTitle: Collect and ship Apache HTTPD server metrics to Logstash and Elasticse
 logo: apache
 color: "#cc2235"
 description: How to send Apache server metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send Apache HTTPD server metrics to Logstash or Elasticsearch. 
-stackTypes: metrics
+stackTypes: logs
 sslPortType: beats-ssl
 tags: Metrics, Metricbeat, Stats, Apache, Apache2, HTTP, HTTPd, Web, Web Server, Module
 ---

--- a/src/pages/integrations/infrastructure-metrics/platforms/metricbeat-module-docker.mdx
+++ b/src/pages/integrations/infrastructure-metrics/platforms/metricbeat-module-docker.mdx
@@ -5,7 +5,7 @@ subTitle: Collect and ship Docker container service metrics to Logstash and Elas
 logo: docker
 color: "#008bb6"
 description: How to send Docker container metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send Docker container metrics to Logstash or Elasticsearch. 
-stackTypes: metrics
+stackTypes: logs
 sslPortType: beats-ssl
 tags: Metrics, Metricbeat, Stats, Docker, Container, Containerization, Module
 ---

--- a/src/pages/integrations/infrastructure-metrics/platforms/metricbeat-module-haproxy.mdx
+++ b/src/pages/integrations/infrastructure-metrics/platforms/metricbeat-module-haproxy.mdx
@@ -5,7 +5,7 @@ subTitle: Collect and ship HAProxy server metrics to Logstash and Elasticsearch
 logo: haproxy
 color: "#009edb"
 description: How to send HAProxy metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send HAProxy server metrics to Logstash or Elasticsearch. 
-stackTypes: metrics
+stackTypes: logs
 sslPortType: beats-ssl
 tags: Metrics, Metricbeat, Stats, HAProxy, Proxy, Web, HTTP, Load Balancer, Module, Haproxy
 ---

--- a/src/pages/integrations/infrastructure-metrics/platforms/metricbeat-module-kafka.mdx
+++ b/src/pages/integrations/infrastructure-metrics/platforms/metricbeat-module-kafka.mdx
@@ -5,7 +5,7 @@ subTitle: Collect and ship Kafka server metrics to Logstash and Elasticsearch
 logo: kafka
 color: "#723244"
 description: How to send Kafka server metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send Apache Kafka server metrics to Logstash or Elasticsearch. 
-stackTypes: metrics
+stackTypes: logs
 sslPortType: beats-ssl
 tags: Metrics, Metricbeat, Stats, Kafka, Message Queue, Module
 ---

--- a/src/pages/integrations/infrastructure-metrics/platforms/metricbeat-module-nginx.mdx
+++ b/src/pages/integrations/infrastructure-metrics/platforms/metricbeat-module-nginx.mdx
@@ -5,7 +5,7 @@ subTitle: Collect and ship NGINX server metrics to Logstash and Elasticsearch
 logo: nginx
 color: "#00aa4e"
 description: How to send NGINX server metrics to your Hosted ELK Logstash instance. Configure Metricbeat to send NGINX web server metrics to Logstash or Elasticsearch. 
-stackTypes: metrics
+stackTypes: logs
 sslPortType: beats-ssl
 tags: Metrics, Metricbeat, Stats, Nginx, Web, HTTP, Web Server, Module
 ---

--- a/src/pages/integrations/infrastructure-metrics/platforms/metricbeat-module-zookeeper.mdx
+++ b/src/pages/integrations/infrastructure-metrics/platforms/metricbeat-module-zookeeper.mdx
@@ -5,7 +5,7 @@ subTitle: Collect and ship Apache ZooKeeper server metrics to Logstash and Elast
 logo: zookeeper
 color: "#437e2d"
 description: Follow our Apache Zookeeper tutorial to ship Apache Zookeeper Server Metrics Logstash for monitoring and analysis. 
-stackTypes: metrics
+stackTypes: logs
 sslPortType: beats-ssl
 tags: Metrics, Metricbeat, Stats, System, Microsoft, Windows, Apache, Zookeeper, Distributed Systems, Module
 ---


### PR DESCRIPTION
Various integrations that use metricbeat were set to be of 'stackTypes: metrics' but needed to be 'stackTypes: logs' to display properly. This PR addresses that issue.