### PR TITLE
Bug - fix source trying to strip quotes from a number field

### DIFF
--- a/src/pages/integrations/otel-collector.mdx
+++ b/src/pages/integrations/otel-collector.mdx
@@ -90,7 +90,7 @@ The OpenTelemetry Collector allows you to send logs, metrics and traces to your 
     otlp:
       auth:
         authenticator: basicauth/apm
-      endpoint: '@opentelemetry.endpointAddress:strip_quotes:@opentelemetry.grpcPort:strip_quotes'
+      endpoint: '@opentelemetry.endpointAddress:strip_quotes:@opentelemetry.grpcPort'
     logging:
       verbosity: detailed
   service:


### PR DESCRIPTION
This was throwing an error when trying to strip the quotes from a number field - so I've removed the strip_quotes part.

There a corresponding docs PR that prevents a number field from throwing an exception by converting the field to a string before trying string.replace on it.