### PR TITLE
Added front matter for winlogbeat dashboard ids.

### DIFF
--- a/src/pages/integrations/winlogbeat.mdx
+++ b/src/pages/integrations/winlogbeat.mdx
@@ -9,6 +9,7 @@ description: Winlogbeat is a Windows-specific event log-shipping agent.
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Beats, Logs, Windows, Microsoft, System, Event Log, Logging, Winlogbeat
+dashboardIds: winlogbeat
 ---
 
 Winlogbeat is a Windows specific event-log shipping agent installed 


### PR DESCRIPTION
Simple PR to add the dashboard Id to the front matter of the Winlogbeat integration guide.