### PR TITLE
Adding stack types to pages

### DIFF
--- a/src/pages/application-performance-monitoring/audit-log.mdx
+++ b/src/pages/application-performance-monitoring/audit-log.mdx
@@ -2,6 +2,7 @@
 title: Audit Log
 metaTitle: Learn about Application Performance Monitoring (APM) Audit Logs
 description: Read our in-depth help article to learn how to view the Application Performance Monitoring Audit Log history in Logit.io.
+stackTypes: apm
 ---
 
 # Application Performance Monitoring: Audit Log Overview

--- a/src/pages/application-performance-monitoring/authorized-applications.mdx
+++ b/src/pages/application-performance-monitoring/authorized-applications.mdx
@@ -2,6 +2,7 @@
 title: Configure Authorized Applications
 metaTitle: Learn How to Configure Authorized Applications
 description: Follow our guide to learn how to authorize applications with user credentials for secure tracing in your OpenSearch/Jaeger Stack
+stackTypes: apm
 ---
 
 # How do you ensure that only authorized applications can send traces/spans to OpenSearch

--- a/src/pages/application-performance-monitoring/getting-started.mdx
+++ b/src/pages/application-performance-monitoring/getting-started.mdx
@@ -2,6 +2,7 @@
 title: Get Started Sending Traces
 metaTitle: Learn How to Get Started Sending Traces
 description: Discover the steps you need to take to get started sending traces to Logit.io.
+stackTypes: apm
 ---
 
 # Get Started Sending Traces

--- a/src/pages/application-performance-monitoring/ingestion-pipeline.mdx
+++ b/src/pages/application-performance-monitoring/ingestion-pipeline.mdx
@@ -4,6 +4,7 @@ metaTitle: Learn How to Work with APM Ingestion Pipelines
 description: Read Logit.io's collection of ingestion pipeline articles to learn more about various aspects of working with APM ingestion pipelines. 
 pagination: false
 timestamp: false
+stackTypes: apm
 ---
 
 <FolderBrowser />

--- a/src/pages/application-performance-monitoring/ingestion-pipeline/calculating-span-ingestion.mdx
+++ b/src/pages/application-performance-monitoring/ingestion-pipeline/calculating-span-ingestion.mdx
@@ -2,6 +2,7 @@
 title: Calculating Span Ingestion
 metaTitle: Learn How Logit.io Calculates Span Ingestion
 description: Span ingestion is collecting and incorporating trace data, into a monitoring or observability system. Learn how Logit.io calculates tracing & span ingestion
+stackTypes: apm
 ---
 
 # How does Logit.io calculate span ingestion?

--- a/src/pages/application-performance-monitoring/ingestion-pipeline/opentelemetry-inputs.mdx
+++ b/src/pages/application-performance-monitoring/ingestion-pipeline/opentelemetry-inputs.mdx
@@ -2,6 +2,7 @@
 title: OpenTelemetry Inputs
 metaTitle: Learn How to View and Edit APM OpenTelemetry Inputs
 description: Follow our in-depth help article to learn how to view and edit your APM OpenTelemetry inputs in Logit.io
+stackTypes: apm
 ---
 
 # APM: OpenTelemetry Inputs

--- a/src/pages/application-performance-monitoring/ingestion-pipeline/overview.mdx
+++ b/src/pages/application-performance-monitoring/ingestion-pipeline/overview.mdx
@@ -2,6 +2,7 @@
 title: Overview
 metaTitle: Learn How to use APM Ingestion Pipelines
 description: An ingestion pipeline collects, processes, and stores data from your apps and systems for monitoring and analysis. Learn about Logit.io APM ingestion pipelines
+stackTypes: apm
 ---
 
 # APM Ingestion Pipeline Overview

--- a/src/pages/application-performance-monitoring/jaeger.mdx
+++ b/src/pages/application-performance-monitoring/jaeger.mdx
@@ -4,6 +4,7 @@ metaTitle: Learn How to use Hosted Jaeger for APM
 description: Read Logit.io's collection of Jaeger articles to learn more about various aspects of working with hosted jaeger from Logit.io.
 pagination: false
 timestamp: false
+stackTypes: apm
 ---
 
 <FolderBrowser />

--- a/src/pages/application-performance-monitoring/jaeger/api.mdx
+++ b/src/pages/application-performance-monitoring/jaeger/api.mdx
@@ -2,6 +2,7 @@
 title: Access Jaeger features via REST API
 metaTitle: Learn How to Access Jaeger features via REST API
 description: Read Logit.io’s help article to learn how to access Jaeger features via REST API.
+stackTypes: apm
 ---
 
 # Accessing Jaeger features via REST API

--- a/src/pages/application-performance-monitoring/jaeger/span-types.mdx
+++ b/src/pages/application-performance-monitoring/jaeger/span-types.mdx
@@ -2,6 +2,7 @@
 title: Span Types
 metaTitle: Learn About Various Jaeger Span Types in APM
 description: Categorizing and differentiating spans based on their type is crucial. Learn how to differentiate between different span types in Jaeger with our helpful guide
+stackTypes: apm
 ---
 
 # How can I differentiate between different span types in Jaeger?

--- a/src/pages/application-performance-monitoring/jaeger/viewing-spans-and-traces.mdx
+++ b/src/pages/application-performance-monitoring/jaeger/viewing-spans-and-traces.mdx
@@ -2,6 +2,7 @@
 title: Viewing Spans & Traces
 metaTitle: Learn How to View Spans & Traces in Jaeger
 description: Read our detailed help article to learn how to effectively use Jaeger to view your spans & traces in Logit.io
+stackTypes: apm
 ---
 
 # How to view your spans & traces?

--- a/src/pages/application-performance-monitoring/overview.mdx
+++ b/src/pages/application-performance-monitoring/overview.mdx
@@ -2,6 +2,7 @@
 title: Overview
 metaTitle: Learn How to View and Manage your APM Stack in Logit.io
 description: Follow our in-depth help article to learn how to view and manage your Application Performance Monitoring (APM) stack in Logit.io.
+stackTypes: apm
 ---
 
 # Application Performance Monitoring Overview

--- a/src/pages/application-performance-monitoring/statistics.mdx
+++ b/src/pages/application-performance-monitoring/statistics.mdx
@@ -2,6 +2,7 @@
 title: Statistics
 metaTitle: Learn How to View and Use APM Usage Statistics
 description: Read our help article to learn how Application Performance Monitoring (APM)  usage statistics are calculated in Logit.io
+stackTypes: apm
 ---
 
 # Application Performance Monitoring Statistics

--- a/src/pages/application-performance-monitoring/storage.mdx
+++ b/src/pages/application-performance-monitoring/storage.mdx
@@ -2,6 +2,7 @@
 title: Storage
 metaTitle: Learn about Application Performance Monitoring (APM) Storage
 description: Read our detailed help article to learn how to view and monitor your application performance monitoring (APM) storage in Logit.io
+stackTypes: apm
 ---
 
 ### What is APM Storage?

--- a/src/pages/application-performance-monitoring/troubleshooting.mdx
+++ b/src/pages/application-performance-monitoring/troubleshooting.mdx
@@ -4,6 +4,7 @@ metaTitle: Learn More About the Logit.io APM Platform
 description: Logit.io Documentation for Application Performance Monitoring (APM) Troubleshooting. Follow our guides to learn more about the Logit.io platform.
 pagination: false
 timestamp: false
+stackTypes: apm
 ---
 
 <FolderBrowser />

--- a/src/pages/application-performance-monitoring/troubleshooting/stack-connectivitiy.mdx
+++ b/src/pages/application-performance-monitoring/troubleshooting/stack-connectivitiy.mdx
@@ -2,6 +2,7 @@
 title: Infrastructure to Logit.io Connectivity
 metaTitle: Learn How to Check the Connectivity from Infrastructure to your Stack
 description: Learn how to check the connectivity from your infrastructure to your Logit.io stack and diagnose connectivity issues
+stackTypes: apm
 ---
 
 # Check Connectivity from Infrastructure to your Logit.io Stack

--- a/src/pages/application-performance-monitoring/visualizers.mdx
+++ b/src/pages/application-performance-monitoring/visualizers.mdx
@@ -4,6 +4,7 @@ metaTitle: Learn How to Visualize Traces with APM Visualizer Guides
 description: Read our help article to learn how to view and manage your application performance monitoring (APM) vizualizers in Logit.io
 pagination: false
 timestamp: false
+stackTypes: apm
 ---
 
 # What are APM Visualizations?

--- a/src/pages/infrastructure-metrics/alerting.mdx
+++ b/src/pages/infrastructure-metrics/alerting.mdx
@@ -4,6 +4,7 @@ metaTitle: Learn How to Configure Alerts for Infrastructure Metrics
 description: Read Logit.io's collection of alerting articles to learn more about various aspects of infrastructure metrics alerting in Logit.io.
 pagination: false
 timestamp: false
+stackTypes: metrics
 ---
 
 <FolderBrowser />

--- a/src/pages/infrastructure-metrics/alerting/configure-cpu-alerts.mdx
+++ b/src/pages/infrastructure-metrics/alerting/configure-cpu-alerts.mdx
@@ -2,6 +2,7 @@
 title: Configuring CPU Alerts
 metaTitle: Learn how to Configure CPU Alerts
 description: Follow the steps in our help article to setup and configure CPU alerts to send notifications from Logit.io
+stackTypes: metrics
 ---
 
 # How to configure CPU alerts with Logit.io?

--- a/src/pages/infrastructure-metrics/alerting/configure-disk-usage-alerts.mdx
+++ b/src/pages/infrastructure-metrics/alerting/configure-disk-usage-alerts.mdx
@@ -1,7 +1,8 @@
 ---
 title: Configuring Disk Usage Alerts
 metaTitle: Learn How to Configure Disk Usage Alerts
-description: Follow Logit.io’s in-depth help article to discover how to effectively configure a disk usage alert to Slack from Grafana. 
+description: Follow Logit.io’s in-depth help article to discover how to effectively configure a disk usage alert to Slack from Grafana.
+stackTypes: metrics
 ---
 
 # How to configure a disk usage alert to Slack from Grafana

--- a/src/pages/infrastructure-metrics/alerting/configure-ram-alerts.mdx
+++ b/src/pages/infrastructure-metrics/alerting/configure-ram-alerts.mdx
@@ -2,6 +2,7 @@
 title: Configuring RAM Usage Alerts
 metaTitle: Learn How to Configure RAM Usage Alerts
 description: Follow the simple steps in our help article to setup and configure RAM usage alerts to send notifications from Logit.io
+stackTypes: metrics
 ---
 
 # How to configure RAM usage alerts with Logit.io?

--- a/src/pages/infrastructure-metrics/alerting/overview.mdx
+++ b/src/pages/infrastructure-metrics/alerting/overview.mdx
@@ -2,6 +2,7 @@
 title: Overview
 metaTitle: Learn How to Configure Alerts for Metrics
 description: Discover how to get started with the setup and configuration of Infrastructure Metrics alerts with Logit.io in our helpful guide
+stackTypes: metrics
 ---
 
 # Infrastructure Metrics Alerts Overview

--- a/src/pages/infrastructure-metrics/audit-log.mdx
+++ b/src/pages/infrastructure-metrics/audit-log.mdx
@@ -2,6 +2,7 @@
 title: Audit Log
 metaTitle: Learn about Infrastructure Metrics Audit Logs
 description: Read our help article to learn how to view and work with Infrastructure Metrics Audit Log history in Logit.io
+stackTypes: metrics
 ---
 
 # Infrastructure Metrics: Metrics Audit Log Overview

--- a/src/pages/infrastructure-metrics/getting-started.mdx
+++ b/src/pages/infrastructure-metrics/getting-started.mdx
@@ -3,6 +3,7 @@ title: Get Started Sending Metrics
 metaTitle: Learn How to Get Started Sending Metrics
 stackTypes: metrics
 description: Read Logit.io’s in-depth help article to learn how to get started and explore Infrastructure Metrics with Grafana
+stackTypes: metrics
 ---
 
 # Get Started Sending Metric Data

--- a/src/pages/infrastructure-metrics/ingestion-pipeline.mdx
+++ b/src/pages/infrastructure-metrics/ingestion-pipeline.mdx
@@ -4,6 +4,7 @@ metaTitle: Learn How to Use Infrastructure Metrics Ingestion Pipelines
 description: Read Logit.io's collection of ingestion pipeline articles to learn more about various aspects of working with infrastructure metrics ingestion pipelines.
 pagination: false
 timestamp: false
+stackTypes: metrics
 ---
 
 <FolderBrowser />

--- a/src/pages/infrastructure-metrics/ingestion-pipeline/overview.mdx
+++ b/src/pages/infrastructure-metrics/ingestion-pipeline/overview.mdx
@@ -2,6 +2,7 @@
 title: Ingestion Pipeline
 metaTitle: Learn How to use Infrastructure Metrics Ingestion Pipeline
 description: An Infrastructure Metrics Ingestion Pipeline is a system designed to collect, process, and store metrics and performance data.
+stackTypes: metrics
 ---
 
 # Infrastructure Metrics: Ingestion Pipeline

--- a/src/pages/infrastructure-metrics/ingestion-pipeline/remote-write.mdx
+++ b/src/pages/infrastructure-metrics/ingestion-pipeline/remote-write.mdx
@@ -2,6 +2,7 @@
 title: Remote Write
 metaTitle: Learn How to Use Infrastructure Metrics Remote Write
 description: Remote write is a mechanism that sends metric data from one component to another. Learn how to use and configure Infrastructure Metrics Remote Write in Logit.io
+stackTypes: metrics
 ---
 
 # Infrastructure Metrics: Remote Write

--- a/src/pages/infrastructure-metrics/ingestion-pipeline/scrape-config.mdx
+++ b/src/pages/infrastructure-metrics/ingestion-pipeline/scrape-config.mdx
@@ -2,6 +2,7 @@
 title: Scrape Config
 metaTitle: Learn How to Use Infrastructure Metrics Scrape Config
 description: Read our help article to learn how to add Infrastructure Metrics config for Victoria Metrics Agent in Logit.io
+stackTypes: metrics
 ---
 
 # Infrastructure Metrics: Scrape Config Overview

--- a/src/pages/infrastructure-metrics/metrics-volume-count.mdx
+++ b/src/pages/infrastructure-metrics/metrics-volume-count.mdx
@@ -2,6 +2,7 @@
 title: Metrics Volume Count
 metaTitle: Learn How to Check Infrastructure Metrics Metrics Volume Count
 description: Read our help article to learn how to check your Infrastructure Metrics Metrics Volume Count in Logit.io
+stackTypes: metrics
 ---
 
 # Infrastructure Metrics: Metrics Volume Count

--- a/src/pages/infrastructure-metrics/overview.mdx
+++ b/src/pages/infrastructure-metrics/overview.mdx
@@ -2,6 +2,7 @@
 title: Overview
 metaTitle: Learn How to View and Manage your Infrastructure Metrics Stack
 description: Read our thorough help article to learn how to view and manage your Infrastructure Metrics stack in Logit.io.
+stackTypes: metrics
 ---
 
 # Infrastructure Metrics Overview

--- a/src/pages/infrastructure-metrics/statistics.mdx
+++ b/src/pages/infrastructure-metrics/statistics.mdx
@@ -2,6 +2,7 @@
 title: Statistics
 metaTitle: Learn How to View and Use Infrastructure Metrics Usage Statistics
 description: Read our information help article to learn how Infrastructure Metrics usage statistic is calculated in Logit.io
+stackTypes: metrics
 ---
 
 # Statistics

--- a/src/pages/infrastructure-metrics/storage.mdx
+++ b/src/pages/infrastructure-metrics/storage.mdx
@@ -2,6 +2,7 @@
 title: Storage Overview
 metaTitle: Learn about Infrastructure Metrics Storage
 description: Read our help article to learn about how to work with and understand Infrastructure Metrics Storage in Logit.io
+stackTypes: metrics
 ---
 
 # What is Infrastructure Metrics Storage?

--- a/src/pages/infrastructure-metrics/visualizers.mdx
+++ b/src/pages/infrastructure-metrics/visualizers.mdx
@@ -2,6 +2,7 @@
 title: Visualizers
 metaTitle: Learn How to Visualize Metrics with Grafana
 description: Read our help article to learn about how to work with Infrastructure Metrics visualizers and dashboards in Logit.io
+stackTypes: metrics
 ---
 
 # What are Grafana Dashboards/Visualizations?

--- a/src/pages/infrastructure-metrics/visualizers/api.mdx
+++ b/src/pages/infrastructure-metrics/visualizers/api.mdx
@@ -2,6 +2,7 @@
 title: Access Grafana features via REST API
 metaTitle: Learn How to Access Grafana features via REST API
 description: Read Logit.io’s help article to learn how to access Grafana features via REST API.
+stackTypes: metrics
 ---
 
 # Accessing Grafana features via REST API

--- a/src/pages/infrastructure-metrics/visualizers/grafana.mdx
+++ b/src/pages/infrastructure-metrics/visualizers/grafana.mdx
@@ -2,6 +2,7 @@
 title: View Infrastructure Metrics with Grafana
 metaTitle: Learn How to View Infrastructure Metrics with Grafana
 description: Follow our getting started help article to learn how to use Grafana to effectively view your metrics in Logit.io.
+stackTypes: metrics
 ---
 
 # Getting Started - How to view your Infrastructure Metrics with Grafana

--- a/src/pages/log-management/alerting.mdx
+++ b/src/pages/log-management/alerting.mdx
@@ -4,6 +4,7 @@ metaTitle: Learn How to Get Started with Creating Alerts
 Description: Logit.io documentation. Follow our help articles outlining how to configure alerts and notifications for various log management scenarios.
 pagination: false
 timestamp: false
+stackTypes: logs
 ---
 
 <FolderBrowser />

--- a/src/pages/log-management/alerting/configuration.mdx
+++ b/src/pages/log-management/alerting/configuration.mdx
@@ -4,6 +4,7 @@ metaTitle: Follow Various Guides to Configure Alerts for Logs
 description: Read Logit.io's detailed documentation to successfully configure various alerts and notifications with Logit.io.
 pagination: false
 timestamp: false
+stackTypes: logs
 ---
 
 <FolderBrowser />

--- a/src/pages/log-management/alerting/configuration/change-event-alerts.mdx
+++ b/src/pages/log-management/alerting/configuration/change-event-alerts.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configure Change Alerts for OpenSearch
 description: Find out more about how to create a change alert for your OpenSearch logs or metrics in this article from Logit.io.
+stackTypes: logs
 ---
 
 # Configure Change Alerts for OpenSearch

--- a/src/pages/log-management/alerting/configuration/flatline-alerts.mdx
+++ b/src/pages/log-management/alerting/configuration/flatline-alerts.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configure Flatline Alerts for OpenSearch
 description: Find out more about how to create a flatline alert for your OpenSearch logs or metrics in this article from Logit.io.
+stackTypes: logs
 ---
 
 # Configure Flatline Alerts for OpenSearch

--- a/src/pages/log-management/alerting/configuration/frequency-alerts.mdx
+++ b/src/pages/log-management/alerting/configuration/frequency-alerts.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configure Frequency Alerts for OpenSearch
 description: Create a frequency alert for logs/metrics. When log count exceeds a certain number of events within a time interval, trigger an alert
+stackTypes: logs
 ---
 
 # Configure Frequency Alerts for OpenSearch

--- a/src/pages/log-management/alerting/configuration/high-cpu-alerts.mdx
+++ b/src/pages/log-management/alerting/configuration/high-cpu-alerts.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configure High CPU OpenSearch Alerts for Logs
 description: Read Logit.io’s in-depth help article to learn how to get started and explore OpenSearch Alerting for Log Management
+stackTypes: logs
 ---
 
 # Configure OpenSearch Notifications for High CPU Alerts for Logs

--- a/src/pages/log-management/alerting/configuration/match-all-event-alerts.mdx
+++ b/src/pages/log-management/alerting/configuration/match-all-event-alerts.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configure OpenSearch Alerts to Match Events For a Query
 description: Read Logit.io’s detailed help article to learn how to create any match alert for your OpenSearch logs or metrics
+stackTypes: logs
 ---
 
 # Configure Alerts for OpenSearch to match all/any events for a specific query

--- a/src/pages/log-management/alerting/configuration/percentage-match-alerts.mdx
+++ b/src/pages/log-management/alerting/configuration/percentage-match-alerts.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configure OpenSearch Percentage Match Alerts
 description: Follow the steps in Logit.io’s guide to learn how to create a percentage match alert for your OpenSearch logs or metrics
+stackTypes: logs
 ---
 
 # Configure Percentage Match Alerts for OpenSearch

--- a/src/pages/log-management/alerting/configuration/set-alert-volume-to-prevent-exceeding-stack-limit.mdx
+++ b/src/pages/log-management/alerting/configuration/set-alert-volume-to-prevent-exceeding-stack-limit.mdx
@@ -1,6 +1,7 @@
 ---
 title: Alert For Log Volume To Stop Exceeding Stack Limit
 description: Read Logit.io’s in-depth help article to learn how to set up an alert for a log volume to stop you from exceeding your stack limit
+stackTypes: logs
 ---
 
 # How to set an alert for a log volume to stop you from exceeding your stack limit

--- a/src/pages/log-management/alerting/configuration/spike-alerts.mdx
+++ b/src/pages/log-management/alerting/configuration/spike-alerts.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configure Spike Alerts for OpenSearch
 description: Find out more about how to create a spike alert for your OpenSearch logs or metrics in this article from Logit.io.
+stackTypes: logs
 ---
 
 # Configure Spike Alerts for OpenSearch

--- a/src/pages/log-management/alerting/creating-alerts.mdx
+++ b/src/pages/log-management/alerting/creating-alerts.mdx
@@ -2,6 +2,7 @@
 title: How Do I Create a New Alerting Rule?
 metaTitle: Learn How to Create a New Alerting Rule
 description: Discover the steps you need to take to create Elasticsearch alert rules in this help article from Logit.io.
+stackTypes: logs
 ---
 
 # How do I create a new Alerting rule?

--- a/src/pages/log-management/alerting/notifications.mdx
+++ b/src/pages/log-management/alerting/notifications.mdx
@@ -4,6 +4,7 @@ metaTitle: Learn How to Configure Alerts & Notifications for Log Management
 description: Read Logit.io's collection of in-depth notification articles to learn more about various aspects of working with notifications in Logit.io.
 pagination: false
 timestamp: false
+stackTypes: logs
 ---
 
 <FolderBrowser />

--- a/src/pages/log-management/alerting/notifications/emails.mdx
+++ b/src/pages/log-management/alerting/notifications/emails.mdx
@@ -1,6 +1,7 @@
 ---
 title: Send Email Alerts & Notifications from Logit.io
 description: Discover the steps you need to take to setup and configure email alerts from your Logit.io ELK stacks in this helpful article.
+stackTypes: logs
 ---
 
 # How to send email alerts & notifications from Logit

--- a/src/pages/log-management/alerting/notifications/opsgenie.mdx
+++ b/src/pages/log-management/alerting/notifications/opsgenie.mdx
@@ -1,6 +1,7 @@
 ---
 title: How To Send Alerts from Logit.io to OpsGenie
 description: Follow the steps in Logit.io’s help article to setup and configure alerts and notifications from your Stacks to OpsGenie
+stackTypes: logs
 ---
 
 # How to send alerts from Logit.io to OpsGenie

--- a/src/pages/log-management/alerting/notifications/pagerduty.mdx
+++ b/src/pages/log-management/alerting/notifications/pagerduty.mdx
@@ -1,6 +1,7 @@
 ---
 title: Send Alerts & Notifs from Logit.io to PagerDuty
 description: Discover how to get started with the setup and configuration required to send alert notifications to PagerDuty in this article.
+stackTypes: logs
 ---
 
 # How to send alerts & notifications from Logit.io to PagerDuty

--- a/src/pages/log-management/alerting/notifications/slack.mdx
+++ b/src/pages/log-management/alerting/notifications/slack.mdx
@@ -1,6 +1,7 @@
 ---
 title: Send Alerts & Notifications from Logit.io to Slack
 description: Discover the steps you need to take to setup and configure alerts notifications to be sent to Slack in this helpful article from Logit.io.
+stackTypes: logs
 ---
 
 # How to send alerts & notifications from Logit.io to Slack

--- a/src/pages/log-management/alerting/overview.mdx
+++ b/src/pages/log-management/alerting/overview.mdx
@@ -2,6 +2,7 @@
 title: Overview
 metaTitle: Learn How to Configure Alerts for Logs
 description: Discover how to get started with the setup and configuration of alerts with Logit.io in our helpful guide.
+stackTypes: logs
 ---
 
 # An introduction to Alerting

--- a/src/pages/log-management/alerting/sending-alert-notifications.mdx
+++ b/src/pages/log-management/alerting/sending-alert-notifications.mdx
@@ -2,6 +2,7 @@
 title: Sending Alerts from Logs Stack for Different Scenarios
 metaTitle: Learn How to Send Alerts from Logs Stack
 description: Read Logit.io’s help article to setup and configure log alerting for more advanced scenarios including FAQs
+stackTypes: logs
 ---
 
 # Options for sending alerts from your logs stack for different scenarios

--- a/src/pages/log-management/alerting/using-html-in-email-alerts.mdx
+++ b/src/pages/log-management/alerting/using-html-in-email-alerts.mdx
@@ -2,6 +2,7 @@
 title: Can I Use HTML in Email Alerts?
 metaTitle: Learn if you can use HTML in Email Alerts
 description: Find out if it is possible to use HTML in Elastalert alerts by following the steps outlined in this help article from Logit.io.
+stackTypes: logs
 ---
 
 # Can I use HTML in email alerts?

--- a/src/pages/log-management/alerting/validating-alert-rules.mdx
+++ b/src/pages/log-management/alerting/validating-alert-rules.mdx
@@ -2,6 +2,7 @@
 title: Check Elastalert Rule is Configured Correctly
 metaTitle: Learn How to Check Elastalert Rule is Configured Correctly
 description: Follow the steps in Logit.io’s help article to guarante that your Elastalert yaml file is formatted and configured correctly
+stackTypes: logs
 ---
 
 # How can I check my Elastalert rule is configured correctly?

--- a/src/pages/log-management/faqs.mdx
+++ b/src/pages/log-management/faqs.mdx
@@ -4,6 +4,7 @@ metaTitle: Troubleshoot Log Management with FAQs
 description: Read Logit.io's collection of F.A.Q articles to learn more about commonly asked questions relating to Logit.io's log management.
 pagination: false
 timestamp: false
+stackTypes: logs
 ---
 
 <FolderBrowser />

--- a/src/pages/log-management/faqs/how-to-add-opensearch-java-client.mdx
+++ b/src/pages/log-management/faqs/how-to-add-opensearch-java-client.mdx
@@ -2,6 +2,7 @@
 title: How to add the OpenSearch Java client
 metaTitle: Learn How to Add the OpenSearch Java Client
 description: Read our help article to learn how to integrate the OpenSearch Java client with Logit.io's OpenSearch service.
+stackTypes: logs
 ---
 
 # Integrating the OpenSearch Java client with Logit.io's OpenSearch service

--- a/src/pages/log-management/faqs/how-to-send-azure-logs-and-metrics.mdx
+++ b/src/pages/log-management/faqs/how-to-send-azure-logs-and-metrics.mdx
@@ -2,6 +2,7 @@
 title: Sending Azure Logs and Metrics to Logit.io
 metaTitle: Learn How to Send Azure Logs and Metrics to Logit.io
 description: This article will break down the various Azure source integrations that you can implement in Logit.io. Learn how to send Azure logs to Logit.io
+stackTypes: logs
 ---
 
 # Sending Azure Logs to Logit.io

--- a/src/pages/log-management/faqs/what-are-the-risks-of-sending-data-via-udp.mdx
+++ b/src/pages/log-management/faqs/what-are-the-risks-of-sending-data-via-udp.mdx
@@ -2,6 +2,7 @@
 title: What are the risks of sending data via UDP
 metaTitle: Learn the Risks of Sending Data via UDP
 description: Discover the steps you need to take to send log data to ElasticSearch via UDP in this help article from Logit.io.
+stackTypes: logs
 ---
 
 # Understanding UDP

--- a/src/pages/log-management/getting-started.mdx
+++ b/src/pages/log-management/getting-started.mdx
@@ -4,7 +4,6 @@ metaTitle: Learn How to Get Started with Log Management
 pagination: false
 timestamp: false
 stackTypes: logs
-stackTypes: logs
 ---
 
 ## Getting Started Sending Logs to Your Logit.io Stack

--- a/src/pages/log-management/getting-started.mdx
+++ b/src/pages/log-management/getting-started.mdx
@@ -4,6 +4,7 @@ metaTitle: Learn How to Get Started with Log Management
 pagination: false
 timestamp: false
 stackTypes: logs
+stackTypes: logs
 ---
 
 ## Getting Started Sending Logs to Your Logit.io Stack

--- a/src/pages/log-management/grafana.mdx
+++ b/src/pages/log-management/grafana.mdx
@@ -4,6 +4,7 @@ metaTitle: Learn How to use and Visualize Logs in Grafana
 description: Logit.io's documentation includes help articles for Grafana. Read Log Management - Grafana articles to learn more about Hosted Grafana with Logit.io
 pagination: false
 timestamp: false
+stackTypes: logs
 ---
 
 <FolderBrowser />

--- a/src/pages/log-management/grafana/api.mdx
+++ b/src/pages/log-management/grafana/api.mdx
@@ -2,6 +2,7 @@
 title: Access Grafana features via REST API
 metaTitle: Learn How to Access Grafana features via REST API
 description: Read Logit.io’s help article to learn how to access Grafana features via REST API.
+stackTypes: logs
 ---
 
 # Accessing Grafana features via REST API

--- a/src/pages/log-management/grafana/viewing-logs.mdx
+++ b/src/pages/log-management/grafana/viewing-logs.mdx
@@ -2,6 +2,7 @@
 title: Viewing Logs in Grafana
 metaTitle: Learn How to View Logs in Grafana
 description: Read logit.io’s detailed help article to learn how to get started and explore your logs in log management with Grafana
+stackTypes: logs
 ---
 
 # Viewing Logs in Grafana

--- a/src/pages/log-management/ingestion-pipeline.mdx
+++ b/src/pages/log-management/ingestion-pipeline.mdx
@@ -4,6 +4,7 @@ metaTitle: Learn How to Use Logs Ingestion Pipelines
 description: Read Logit.io's collection of ingestion pipeline articles to learn more about various aspects of working with log management ingestion pipelines.
 pagination: false
 timestamp: false
+stackTypes: logs
 ---
 
 <FolderBrowser />

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs.mdx
@@ -4,6 +4,7 @@ metaTitle: Learn How to Add Inputs to Your Logstash Instance
 description: Follow the steps outlined in the various input articles from Logit.io to learn how to add an input to your Logstash instance.
 pagination: false
 timestamp: false
+stackTypes: logs
 ---
 
 <FolderBrowser />

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-amazon-s3-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-amazon-s3-input.mdx
@@ -2,6 +2,7 @@
 title: Add Amazon S3 Input
 metaTitle: Learn How to Add Amazon S3 Input
 description: Follow the simple steps outlined in Logit.io’s help article to learn how to configure an Amazon S3 Input on your Logstash Instance
+stackTypes: logs
 ---
 
 # How to add an Amazon S3 Input to your Log Stack

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-azure-event-hub-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-azure-event-hub-input.mdx
@@ -2,6 +2,7 @@
 title: Add Azure Event Hub Input
 metaTitle: Learn How to Add Azure Event Hub Input
 description: Follow Logit.io’s help article to learn how to configure a Azure Event Hub Input on your Logstash Instance.
+stackTypes: logs
 ---
 
 # How to add an Azure Event Hub Input to your Log Stack

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-beats-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-beats-input.mdx
@@ -2,6 +2,7 @@
 title: Add Beats Input
 metaTitle: Learn How to Add Beats Input
 description: Follow the steps outlined in Logit.io’s help article to learn how to configure a Beats Input on your Logstash Instance.
+stackTypes: logs
 ---
 
 # How to add a Beats Input to your Log Stack

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-gelf-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-gelf-input.mdx
@@ -2,6 +2,7 @@
 title: Add GELF Input
 metaTitle: Learn How to Add a GELF Input to your Stack
 description: Follow the simple steps in our help article to successfully configure a GELF Input on your Logstash Instance
+stackTypes: logs
 ---
 
 # How to add a GELF Input to your Log Stack

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-google-cloud-storage-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-google-cloud-storage-input.mdx
@@ -2,6 +2,7 @@
 title: Add Google Cloud Storage Input
 metaTitle: Learn How to Add Google Cloud Storage Input
 description: Follow Logit.io’s steps in this help article to learn how to configure a Google Cloud Storage Input on your Logstash Instance.
+stackTypes: logs
 ---
 
 # How to add a Google Cloud Storage Input to your Log Stack

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-google-pubsub-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-google-pubsub-input.mdx
@@ -2,6 +2,7 @@
 title: Add Google Pub/Sub Input
 metaTitle: Learn How to Add Google Pub/Sub Input
 description: Read our help article to learn how to successfully configure a Google Pub/Sub Input on your Logstash Instance.
+stackTypes: logs
 ---
 
 # How to add a Google Pub/Sub Input to your Log Stack

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-http-ssl-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-http-ssl-input.mdx
@@ -2,6 +2,7 @@
 title: Add a HTTP SSL Input
 metaTitle: Learn How to Add a HTTP SSL Input
 description: Follow the simple steps in Logit.ios help article to successfully configure a HTTP SSL Input on your Logstash Instance
+stackTypes: logs
 ---
 
 # How to add a HTTP SSL Input to your Log Stack

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-sqs-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-sqs-input.mdx
@@ -2,6 +2,7 @@
 title: Add SQS Input
 metaTitle: Learn How to Add a SQS Input to your stack
 description: Read our help article and follow the simple steps to learn how to configure a SQS Input on your Logstash Instance
+stackTypes: logs
 ---
 
 # How to add a SQS Input to your Log Stack

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-syslog-ssl-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-syslog-ssl-input.mdx
@@ -2,6 +2,7 @@
 title: Add Syslog SSL Input
 metaTitle: Learn How to Add a Syslog SSL Input
 description: Follow the simple steps in Logit.io’s help article to learn how to configure a Syslog SSL Input on your Logstash Instance
+stackTypes: logs
 ---
 
 # How to add a Syslog SSL Input to your Log Stack

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-syslog-tcp-udp-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-syslog-tcp-udp-input.mdx
@@ -2,6 +2,7 @@
 title: Add Syslog TCP or UDP Input
 metaTitle: Learn How to Add a Syslog TCP or UDP Input
 description: Follow our simple help article to learn how to configure a Syslog TCP or UDP Input on your Logstash Instance
+stackTypes: logs
 ---
 
 # How to add a Syslog TCP or UDP Input to your Log Stack

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-tcp-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-tcp-input.mdx
@@ -2,6 +2,7 @@
 title: Add TCP Input
 metaTitle: Learn How to Add a TCP Input to your stack
 description: Follow the simple steps in Logit.io’s help article to learn how to configure a Syslog TCP Input on your Logstash Instance
+stackTypes: logs
 ---
 
 # How to add a TCP Input to your Log Stack

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-tcp-ssl-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-tcp-ssl-input.mdx
@@ -2,6 +2,7 @@
 title: Add TCP SSL Input
 metaTitle: Learn How to Add a TCP SSL Input
 description: Follow the simple steps outlined in Logit.io’s help article to learn how to add a TCP SSL Input to your Logstash Instance
+stackTypes: logs
 ---
 
 # How to add a TCP SSL Input to your Log Stack

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-udp-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-udp-input.mdx
@@ -2,6 +2,7 @@
 title: Add UDP Input
 metaTitle: Learn How to Add a UDP Input to your Stack
 description: Read our guide and follow the simple steps to learn how to configure a UDP Input on your Logstash Instance
+stackTypes: logs
 ---
 
 # How to add a UDP Input to your Log Stack

--- a/src/pages/log-management/ingestion-pipeline/api-key-logstash.mdx
+++ b/src/pages/log-management/ingestion-pipeline/api-key-logstash.mdx
@@ -2,6 +2,7 @@
 title: How To Use Your API Key in Logstash
 metaTitle: Learn How to Use Your API Key in Logstash
 description: Discover the steps you need to take to send log files securely to Logstash using an API key in this helpful article from Logit.io
+stackTypes: logs
 ---
 
 # How to use your API Key in Logstash

--- a/src/pages/log-management/ingestion-pipeline/change-index-names-from-logstash.mdx
+++ b/src/pages/log-management/ingestion-pipeline/change-index-names-from-logstash.mdx
@@ -2,6 +2,7 @@
 title: Changing Index Names in Logstash
 metaTitle: Learn How to Change Index Names in Logstash
 description: Follow our help article to learn how to specify different index names in OpenSearch in this article from Logit.io
+stackTypes: logs
 ---
 
 # How can I change the index names from logstash-\*

--- a/src/pages/log-management/ingestion-pipeline/configuration.mdx
+++ b/src/pages/log-management/ingestion-pipeline/configuration.mdx
@@ -4,6 +4,7 @@ metaTitle: Learn How to Configure Logstash Filters, Firewalls, and Inputs
 description: Read Logit.io's collection of ingestion pipeline related configuration articles to learn about aspects of log management ingestion pipeline configurations.
 pagination: false
 timestamp: false
+stackTypes: logs
 ---
 
 <FolderBrowser />

--- a/src/pages/log-management/ingestion-pipeline/configuration/configure-logstash-filters.mdx
+++ b/src/pages/log-management/ingestion-pipeline/configuration/configure-logstash-filters.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configuring Logstash Filters
 description: Learn how to edit Logstash filters to manage and transform data in Logstash in this article from Logit.io.
+stackTypes: logs
 ---
 
 # How can I edit my Logstash Filters?

--- a/src/pages/log-management/ingestion-pipeline/configuration/configure-logstash-firewall.mdx
+++ b/src/pages/log-management/ingestion-pipeline/configuration/configure-logstash-firewall.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configuring Logstash Firewall
 description: Learn how to manage hosted Logstash firewall configurations to restrict which IP addresses can send data to your Logstash endpoints
+stackTypes: logs
 ---
 
 # Managing Stack Logstash Firewall Configurations

--- a/src/pages/log-management/ingestion-pipeline/configuration/configure-logstash-inputs.mdx
+++ b/src/pages/log-management/ingestion-pipeline/configuration/configure-logstash-inputs.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configuring Logstash Inputs
 description: Unlocking Seamless Data Integration - Logstash Input Configuration Guide with Amazon S3, Azure Event Hub, Google and More
+stackTypes: logs
 ---
 
 # How to Configure Logstash Inputs for Seamless Data Integration

--- a/src/pages/log-management/ingestion-pipeline/differentiate-log-types-logstash.mdx
+++ b/src/pages/log-management/ingestion-pipeline/differentiate-log-types-logstash.mdx
@@ -2,6 +2,7 @@
 title: Differentiating Log Types in Logstash
 metaTitle: Learn How to Differentiate Log Types in Logstash
 description: Find out more about how to create separate indexes for log types using hosted Logstash in this article from Logit.io.
+stackTypes: logs
 ---
 
 # How can I differentiate between different log types in Logstash

--- a/src/pages/log-management/ingestion-pipeline/logstash-dead-letter-queue.mdx
+++ b/src/pages/log-management/ingestion-pipeline/logstash-dead-letter-queue.mdx
@@ -2,6 +2,7 @@
 title: Logstash Dead Letter Queue (DLQ)
 metaTitle: Learn How to Use The Logstash Dead Letter Queue (DLQ)
 description: Learn how to use the Logstash Dead Letter Queue (DLQ) to diagnose and troubleshooting data missing and not arriving in your stack
+stackTypes: logs
 ---
 
 # Logstash Dead Letter Queue (DLQ): Diagnosing and Troubleshooting Data Issues in OpenSearch on Logit.io

--- a/src/pages/log-management/ingestion-pipeline/overview.mdx
+++ b/src/pages/log-management/ingestion-pipeline/overview.mdx
@@ -2,6 +2,7 @@
 title: Overview
 metaTitle: Learn About the Log Management Ingestion Pipeline
 description: Read our help article to learn about and work with Log Management Ingestion Pipelines on the Logit.io platform
+stackTypes: logs
 ---
 
 # Log Management: Ingestion Pipeline Overview

--- a/src/pages/log-management/ingestion-pipeline/remove-fields-logstash-filters.mdx
+++ b/src/pages/log-management/ingestion-pipeline/remove-fields-logstash-filters.mdx
@@ -2,6 +2,7 @@
 title: Removing Fields with Logstash Filters
 metaTitle: Learn How to Remove Fields in Logstash Filters
 description: Learn the best practices for removing and mutating fields in your logs and metrics using Logstash filters
+stackTypes: logs
 ---
 
 # How do I remove fields using Logstash filters?

--- a/src/pages/log-management/kibana.mdx
+++ b/src/pages/log-management/kibana.mdx
@@ -4,6 +4,7 @@ metaTitle: Learn How to use and Visualize Logs in Kibana
 description: Read Logit.io's collection of in-depth Kibana articles to learn more about various aspects of working with Hosted Kibana from Logit.io.
 pagination: false
 timestamp: false
+stackTypes: logs
 ---
 
 <FolderBrowser />

--- a/src/pages/log-management/kibana/api.mdx
+++ b/src/pages/log-management/kibana/api.mdx
@@ -2,6 +2,7 @@
 title: Access Kibana features via REST API
 metaTitle: Learn How to Access Kibana features via REST API
 description: Read Logit.io’s help article to learn how to access Kibana features via REST API.
+stackTypes: logs
 ---
 
 # Accessing Kibana features via REST API

--- a/src/pages/log-management/kibana/cheatsheet.mdx
+++ b/src/pages/log-management/kibana/cheatsheet.mdx
@@ -2,6 +2,7 @@
 title: Logit.io Kibana Cheatsheet
 metaTitle: Read Logit.io's Kibana Cheatsheet
 description: Utilize Logit.io’s informative and detailed cheatsheet to help with Kibana and Elastic Search Lucene query syntax.
+stackTypes: logs
 ---
 
 # Logit.io Kibana ELK Cheatsheet

--- a/src/pages/log-management/kibana/creating-visualizations.mdx
+++ b/src/pages/log-management/kibana/creating-visualizations.mdx
@@ -2,6 +2,7 @@
 title: Creating Visualizations
 metaTitle: Learn How to Create Visualizations in Logit.io
 description: Read Logit.io’s help article to understand the types of visualization options available for Logs when using Logit.io.
+stackTypes: logs
 ---
 
 # Creating visualizations for my Logs with Logit.io

--- a/src/pages/log-management/kibana/enable-kibana-multi-stack.mdx
+++ b/src/pages/log-management/kibana/enable-kibana-multi-stack.mdx
@@ -2,6 +2,7 @@
 title: Enabling Kibana Multi-Stack
 metaTitle: Learn How to Enable Kibana Multi-Stack
 description: Enabling Kibana multi-stack functionality allows you to manage and visualize data from multiple Elasticsearch clusters using a single Kibana instance.
+stackTypes: logs
 ---
 
 # How to enable Kibana Multi-Stack

--- a/src/pages/log-management/opensearch.mdx
+++ b/src/pages/log-management/opensearch.mdx
@@ -4,6 +4,7 @@ metaTitle: Learn How to use and work with Hosted OpenSearch
 description: Read Logit.io's collection of in-depth OpenSearch articles to learn more about various aspects of working with Hosted OpenSearch from Logit.io.
 pagination: false
 timestamp: false
+stackTypes: logs
 ---
 
 <FolderBrowser />

--- a/src/pages/log-management/opensearch/cold-storage-restoration.mdx
+++ b/src/pages/log-management/opensearch/cold-storage-restoration.mdx
@@ -2,6 +2,7 @@
 title: Restoring data from cold storage
 metaTitle: Learn How to Restore Data from Cold Storage
 description: Follow our in-depth help article to learn how to use cold storage with Amazon S3 for your Logit.io stack
+stackTypes: logs
 ---
 
 # How To Use Cold Storage For Logit.io Stacks & Restore Data.

--- a/src/pages/log-management/opensearch/index-management.mdx
+++ b/src/pages/log-management/opensearch/index-management.mdx
@@ -4,6 +4,7 @@ metaTitle: Learn About Various Aspects of Indexing in OpenSearch
 description: Read Logit.io's collection of in-depth index management articles to learn more about various aspects of indexing with Logit.io
 pagination: false
 timestamp: false
+stackTypes: logs
 ---
 
 <FolderBrowser />

--- a/src/pages/log-management/opensearch/index-management/aggregatable-text-fields.mdx
+++ b/src/pages/log-management/opensearch/index-management/aggregatable-text-fields.mdx
@@ -2,6 +2,7 @@
 title: Aggregatable Text Fields
 metaTitle: Learn About Aggregatable Text Fields in OpenSearch
 description: An aggregatable text field means all values of documents for the text field are loaded into memory. Change the status of a text field to aggregatable.
+stackTypes: logs
 ---
 
 # Aggregatable text fields

--- a/src/pages/log-management/opensearch/index-management/changing-data-on-already-ingested-indexed-opensearch.mdx
+++ b/src/pages/log-management/opensearch/index-management/changing-data-on-already-ingested-indexed-opensearch.mdx
@@ -2,6 +2,7 @@
 title: Changing Field Datatypes
 metaTitle: Learn How to Change Field Datatypes in OpenSearch
 description: Read Logit.io’s help article to learn how to change the datatype of a field for already indexed or sent data in OpenSearch
+stackTypes: logs
 ---
 
 # How do I change the datatype of a field for data already sent/indexed in OpenSearch?

--- a/src/pages/log-management/opensearch/index-management/index-patterns.mdx
+++ b/src/pages/log-management/opensearch/index-management/index-patterns.mdx
@@ -2,6 +2,7 @@
 title: Index Patterns
 metaTitle: Learn How to use index Patterns to Search your Logs and Metrics
 description: What are index patterns and how can I use them to query Elasticsearch with OpenSearch Dashboards on the Logit.io platform?
+stackTypes: logs
 ---
 
 # Using index patterns to search your logs and metrics with OpenSearch

--- a/src/pages/log-management/opensearch/index-management/index-templates.mdx
+++ b/src/pages/log-management/opensearch/index-management/index-templates.mdx
@@ -2,6 +2,7 @@
 title: Index Templates
 metaTitle: Learn How to View OpenSearch Index Templates
 description: Read our article to understand What OpenSearch index templates are and how you can view them for your stacks.
+stackTypes: logs
 ---
 
 # Understanding OpenSearch index templates and how to view them

--- a/src/pages/log-management/opensearch/index-management/listing-indexes.mdx
+++ b/src/pages/log-management/opensearch/index-management/listing-indexes.mdx
@@ -2,6 +2,7 @@
 title: List Indexes
 metaTitle: Learn How to list Indexes in OpenSearch
 description: Listing indexes in an OpenSearch cluster is simple and presents all available indexes and their status. Learn how to list indexes in OpenSearch with Logit.io.
+stackTypes: logs
 ---
 
 # How to list indexes in OpenSearch with Logit.io?

--- a/src/pages/log-management/opensearch/index-management/mapping.mdx
+++ b/src/pages/log-management/opensearch/index-management/mapping.mdx
@@ -4,6 +4,7 @@ metaTitle: Learn How to use and view OpenSearch Index Mappings
 description: Read Logit.io's collection of index mapping articles to learn more about various aspects of index mappings with Logit.io
 pagination: false
 timestamp: false
+stackTypes: logs
 ---
 
 <FolderBrowser />

--- a/src/pages/log-management/opensearch/index-management/mapping/mapping-conflicts.mdx
+++ b/src/pages/log-management/opensearch/index-management/mapping/mapping-conflicts.mdx
@@ -2,6 +2,7 @@
 title: Mapping Conflicts
 metaTitle: Learn About OpenSearch Mapping Conflicts
 description: Discover how OpenSearch mapping conflicts and OpenSearch Dashboards mapping conflicts differ in this helpful guide from Logit.io
+stackTypes: logs
 ---
 
 # How OpenSearch mapping conflict & OpenSearch Dashboards mapping conflict differ

--- a/src/pages/log-management/opensearch/index-management/mapping/mapping-ip-address-info-to-geo-point-fields.mdx
+++ b/src/pages/log-management/opensearch/index-management/mapping/mapping-ip-address-info-to-geo-point-fields.mdx
@@ -2,6 +2,7 @@
 title: Mapping IP Address Info to geo_point Fields
 metaTitle: Learn How to Map IP Adress Info to geo_point Fields
 description: Read Logit.io’s help article to learn how to map IP address data to geo_point fields in OpenSearch dashboards.
+stackTypes: logs
 ---
 
 # Mapping IP Address Info to geo_point Fields

--- a/src/pages/log-management/opensearch/index-management/mapping/overview.mdx
+++ b/src/pages/log-management/opensearch/index-management/mapping/overview.mdx
@@ -2,6 +2,7 @@
 title: Overview
 metaTitle: Learn How to use OpenSearch Mappings
 description: Discover the key facts you need to know about OpenSearch index mappings in this helpful guide from Logit.io
+stackTypes: logs
 ---
 
 # What are OpenSearch Mappings?

--- a/src/pages/log-management/opensearch/index-management/mapping/viewing-mappings.mdx
+++ b/src/pages/log-management/opensearch/index-management/mapping/viewing-mappings.mdx
@@ -2,6 +2,7 @@
 title: How to View Mappings
 metaTitle: Learn How to View OpenSearch Mappings
 description: Discover how to get started with viewing your OpenSearch Mappings in this helpful article from Logit.io
+stackTypes: logs
 ---
 
 # How do I view my OpenSearch Mappings?

--- a/src/pages/log-management/opensearch/index-management/reindexing.mdx
+++ b/src/pages/log-management/opensearch/index-management/reindexing.mdx
@@ -2,6 +2,7 @@
 title: Reindexing
 metaTitle: Learn How to Conduct Reindexing in OpenSearch
 description: Read Logit.io’s in-depth help article to understand how you would use the reindex feature in OpenSearch
+stackTypes: logs
 ---
 
 # How to reindex in OpenSearch?

--- a/src/pages/log-management/opensearch/opensearch-dashboards.mdx
+++ b/src/pages/log-management/opensearch/opensearch-dashboards.mdx
@@ -4,6 +4,7 @@ metaTitle: Learn More About OpenSearch Dashboards
 description: Read Logit.io's collection of OpenSearch Dashboard articles to learn more about various aspects of working with Hosted OpenSearch Dashboards from Logit.io.
 pagination: false
 timestamp: false
+stackTypes: logs
 ---
 
 <FolderBrowser />

--- a/src/pages/log-management/opensearch/opensearch-dashboards/api.mdx
+++ b/src/pages/log-management/opensearch/opensearch-dashboards/api.mdx
@@ -2,6 +2,7 @@
 title: Access Opensearch Dashboard features via REST API
 metaTitle: Learn How to Access Opensearch Dashboards features via REST API
 description: Read Logit.io’s help article to learn how to access Opensearch Dashboards features via REST API.
+stackTypes: logs
 ---
 
 # Accessing Opensearch Dashboards features via REST API

--- a/src/pages/log-management/opensearch/opensearch-dashboards/exporting-and-importing.mdx
+++ b/src/pages/log-management/opensearch/opensearch-dashboards/exporting-and-importing.mdx
@@ -2,6 +2,7 @@
 title: Exporting and Importing
 metaTitle: Learn How to Export and Import Opensearch Visualizations
 description: Read Logit.io’s help article to learn how to migrate visualisations and dashboards from one stack to another stack.
+stackTypes: logs
 ---
 
 # Exporting and Importing OpenSearch Dashboards and Visualisations

--- a/src/pages/log-management/opensearch/opensearch-dashboards/overview.mdx
+++ b/src/pages/log-management/opensearch/opensearch-dashboards/overview.mdx
@@ -2,6 +2,7 @@
 title: Overview
 metaTitle: Learn How to Visualize Data with OpenSearch Dashboards
 description: Read our help article to learn about how to work with Log Management Vizualizers and Dashboards in Logit.io
+stackTypes: logs
 ---
 
 # OpenSearch Dashboards and Visualizations Overview

--- a/src/pages/log-management/opensearch/reporting.mdx
+++ b/src/pages/log-management/opensearch/reporting.mdx
@@ -2,6 +2,7 @@
 title: Reporting
 metaTitle: Learn How to Generate and Schedule Reports with OpenSearch Reporting
 description: Learn how to generate and schedule reports for dashboards, visualisations and saved searches and output to csv, png and pdf
+stackTypes: logs
 ---
 
 # Managing OpenSearch Reporting

--- a/src/pages/log-management/opensearch/searching.mdx
+++ b/src/pages/log-management/opensearch/searching.mdx
@@ -4,6 +4,7 @@ metaTitle: Learn How to Query and Search Your Logs
 description: Read the Searching collection of articles to learn how to conduct various searches with Hosted OpenSearch from Logit.io
 pagination: false
 timestamp: false
+stackTypes: logs
 ---
 
 <FolderBrowser />

--- a/src/pages/log-management/opensearch/searching/disabling-field-searches.mdx
+++ b/src/pages/log-management/opensearch/searching/disabling-field-searches.mdx
@@ -2,6 +2,7 @@
 title: Disabling Field Searches
 metaTitle: Learn How to Disable Field Searches in OpenSearch
 description: Find out more about how to use mappings to define a field as non-searchable in OpenSearch in this article from Logit.io
+stackTypes: logs
 ---
 
 # Disabling the searching of a field in OpenSearch using Index Templates

--- a/src/pages/log-management/opensearch/searching/exporting-search-results.mdx
+++ b/src/pages/log-management/opensearch/searching/exporting-search-results.mdx
@@ -2,6 +2,7 @@
 title: Export Search Results
 metaTitle: Learn How to Export Search Results in OpenSearch
 description: Learn how to export your OpenSearch Dashboards dashboards, visualisations, and search results as either JSON or CSV file formats.
+stackTypes: logs
 ---
 
 # How can I export data from an OpenSearch Dashboards search on Logit?

--- a/src/pages/log-management/opensearch/searching/pagination.mdx
+++ b/src/pages/log-management/opensearch/searching/pagination.mdx
@@ -2,6 +2,7 @@
 title: Pagination
 metaTitle: Learn How to Implement Pagination in OpenSearch
 description: Read Logit.io’s in-depth help article and follow the steps to learn how to implement pagination in OpenSearch
+stackTypes: logs
 ---
 
 # How to implement pagination in OpenSearch?

--- a/src/pages/log-management/opensearch/searching/querying-with-mapper-size.mdx
+++ b/src/pages/log-management/opensearch/searching/querying-with-mapper-size.mdx
@@ -2,6 +2,7 @@
 title: Querying With Mapper Size
 metaTitle: Learn How to Query with Mapper Size in OpenSearch
 description: Read logit.io’s help article to learn how to enable the mapper-size plugin and discover how to query OpenSearch to find large log messages. 
+stackTypes: logs
 ---
 
 # How to query OpenSearch to find large log messages

--- a/src/pages/log-management/opensearch/searching/querying-with-python.mdx
+++ b/src/pages/log-management/opensearch/searching/querying-with-python.mdx
@@ -2,6 +2,7 @@
 title: Querying with Python
 metaTitle: Learn How to Query with Python in OpenSearch
 description: Learn how to craft efficient search queries in OpenSearch, utilizing Python to interact with the Logit.io API.
+stackTypes: logs
 ---
 
 # Querying OpenSearch with Python

--- a/src/pages/log-management/opensearch/searching/querying-with-sql-workbench.mdx
+++ b/src/pages/log-management/opensearch/searching/querying-with-sql-workbench.mdx
@@ -2,6 +2,7 @@
 title: Querying With SQL Workbench
 metaTitle: Learn How to Query with SQL Workbench in OpenSearch
 description: Find out how you can query OpenSearch Dashboards using familiar SQL syntax in this informative help article from Logit.io.
+stackTypes: logs
 ---
 
 # Querying OpenSearch Dashboards using the SQL Workbench

--- a/src/pages/log-management/opensearch/supported-versions.mdx
+++ b/src/pages/log-management/opensearch/supported-versions.mdx
@@ -2,6 +2,7 @@
 title: Supported Stack Versions
 metaTitle: Learn Which OpenSearch and ELK versions Logit.io offers
 description: Details of which Opensearch/Elasticsearch, Logstash and Kibana (ELK) version's Logit.io currently offers
+stackTypes: logs
 ---
 
 # What versions of the Logging Stack does Logit.io support?

--- a/src/pages/log-management/opensearch/timezones.mdx
+++ b/src/pages/log-management/opensearch/timezones.mdx
@@ -2,6 +2,7 @@
 title: Timezones
 metaTitle: Learn How Timezones work in Opensearch
 description: OpenSearch uses the timezone of your browser by default, it is however possible to change this if you require. Learn how to change the timezone for timestamps.
+stackTypes: logs
 ---
 
 # How do timezones work in OpenSearch?

--- a/src/pages/log-management/overview.mdx
+++ b/src/pages/log-management/overview.mdx
@@ -2,6 +2,7 @@
 title: Overview
 metaTitle: Learn How to View and Manage your Log Management Stack
 description: Read our in-depth help article to learn how to view and manage your Log Management stack in Logit.io.
+stackTypes: logs
 ---
 
 # Log Management Overview

--- a/src/pages/log-management/security.mdx
+++ b/src/pages/log-management/security.mdx
@@ -4,6 +4,7 @@ metaTitle: Learn How to Enhance the Security of your Stack
 description: Learn about the security of our platform and the efforts you can make to further secure your data with the secuirty collection of Logit.io's documentation.
 pagination: false
 timestamp: false
+stackTypes: logs
 ---
 
 <FolderBrowser />

--- a/src/pages/log-management/security/authorizing-applications.mdx
+++ b/src/pages/log-management/security/authorizing-applications.mdx
@@ -2,6 +2,7 @@
 title: Authorizing Applications
 metaTitle: Learn How to Ensure Only Authorized Applications Can Send Logs
 description: Read Logit.io’s help article to learn how to ensure that only authorized applications can send logs to Logstash
+stackTypes: logs
 ---
 
 # How to ensure that only authorised applications can send logs to Logstash

--- a/src/pages/log-management/security/multi-tenancy.mdx
+++ b/src/pages/log-management/security/multi-tenancy.mdx
@@ -2,6 +2,7 @@
 title: Multi-Tenancy
 metaTitle: Enhance Security with OpenSearch Dashboards Multi-Tenancy
 description: Learn how to use OpenSearch Multi-Tenancy to manage spaces and control access to indexes, visualisations and dashboards
+stackTypes: logs
 ---
 
 # Managing OpenSearch Dashboards Multi-Tenancy

--- a/src/pages/log-management/security/opensearch-api-access.mdx
+++ b/src/pages/log-management/security/opensearch-api-access.mdx
@@ -2,6 +2,7 @@
 title: OpenSearch API Access
 metaTitle: Learn How to Access your Stack via OpenSearch API
 description: Discover the steps you need to take to access your Logit.io stack via the OpenSearch API in this helpful article from Logit.io.
+stackTypes: logs
 ---
 
 # How to access my stack via the OpenSearch API?

--- a/src/pages/log-management/security/ssl-certificate-expiry-notice.mdx
+++ b/src/pages/log-management/security/ssl-certificate-expiry-notice.mdx
@@ -2,6 +2,7 @@
 title: SSL Certification Expiry Notice
 metaTitle: Learn about the SSL Certification Expiry Notice
 description: Logit.io’s article outlines FAQs, notifications, and guides associated with the rotation of Logstash SSL certificates.
+stackTypes: logs
 ---
 
 # SSL Certificate Expiry Notice

--- a/src/pages/log-management/security/ssl-configuration.mdx
+++ b/src/pages/log-management/security/ssl-configuration.mdx
@@ -2,6 +2,7 @@
 title: SSL Configuration
 metaTitle: Learn How to Update your SSL Configuration
 description: Follow our help article to learn how to update your SSL configuration for Elastic Beats and Rsyslog with Logit.io.
+stackTypes: logs
 ---
 
 # How to update your SSL configuration for Elastic Beats and Rsyslog

--- a/src/pages/log-management/security/whitelisted-hosts.mdx
+++ b/src/pages/log-management/security/whitelisted-hosts.mdx
@@ -2,6 +2,7 @@
 title: Whitelisted Hosts
 metaTitle: Learn How to Ensure Only Whitelisted Hosts Can Send Logs
 description: Read Logit.io’s help article to learn how to ensure only whitelisted hosts can send logs via any inputs
+stackTypes: logs
 ---
 
 # How to ensure only whitelisted hosts can send logs

--- a/src/pages/log-management/troubleshooting.mdx
+++ b/src/pages/log-management/troubleshooting.mdx
@@ -4,6 +4,7 @@ metaTitle: Learn How to use the Logs Management Platform and Diagnose Issues
 description: Learn how to effectively utilize the Logit.io platform and quickly diagnose and resolve difficulties with our log management troubleshooting articles.
 pagination: false
 timestamp: false
+stackTypes: logs
 ---
 
 <FolderBrowser />

--- a/src/pages/log-management/troubleshooting/diagnosing-issues-with-your-filebeat-configuration.mdx
+++ b/src/pages/log-management/troubleshooting/diagnosing-issues-with-your-filebeat-configuration.mdx
@@ -2,6 +2,7 @@
 title: Diagnose Issues with Filebeat Configuration
 metaTitle: Learn How to Diagnose Issues with Filbeat Configuration
 description: Discover how to diagnose issues or problems within your Filebeat configuration in our helpful guide.
+stackTypes: logs
 ---
 
 # Diagnosing issues with your Filebeat configuration

--- a/src/pages/log-management/troubleshooting/how-can-i-diagnose-no-data-appearing.mdx
+++ b/src/pages/log-management/troubleshooting/how-can-i-diagnose-no-data-appearing.mdx
@@ -2,6 +2,7 @@
 title: No Data in Elasticsearch, OpenSearch, or Grafana
 metaTitle: Learn How to Diagnose No Data in Elasticsearch OpenSearch or Grafana
 description: No data appearing in Elasticsearch, OpenSearch or Grafana? Learn how to troubleshoot common issues when sending data to Logit.io Stacks
+stackTypes: logs
 ---
 
 # How can I diagnose no data appearing in Elasticsearch, OpenSearch or Grafana?

--- a/src/pages/log-management/troubleshooting/how-can-i-monitor-my-stack.mdx
+++ b/src/pages/log-management/troubleshooting/how-can-i-monitor-my-stack.mdx
@@ -2,6 +2,7 @@
 title: How Can I Monitor My Stack Health
 metaTitle: Learn How to Monitor your Stack Health
 description: Read Logit.io’s help article for viewing the health and logs for your stacks and resolving common issues and problems
+stackTypes: logs
 ---
 
 # How Can I Monitor My Logit.io Stack Health and Recover From Common Issues?

--- a/src/pages/log-management/troubleshooting/how-do-i-delete-old-indexes-logitio.mdx
+++ b/src/pages/log-management/troubleshooting/how-do-i-delete-old-indexes-logitio.mdx
@@ -2,6 +2,7 @@
 title: How Do I Delete Old Indexes in Logit.io
 metaTitle: Learn How to Delete Old Indexes in Logit.io
 description: Read our help article to find out how to remove old and no longer required indexes and data in Logit.io.
+stackTypes: logs
 ---
 
 # How do I delete old indexes in Logit.io?

--- a/src/pages/log-management/troubleshooting/how-to-create-amazon-s3-bucket.mdx
+++ b/src/pages/log-management/troubleshooting/how-to-create-amazon-s3-bucket.mdx
@@ -2,6 +2,7 @@
 title: How to create an Amazon S3 Bucket
 metaTitle: Learn How to Create an Amazon S3 Bucket
 description: Read Logit.io’s in-depth help article to learn how to onboard and get started sending data using Amazon S3 buckets to your Logs Stack
+stackTypes: logs
 ---
 
 # How to create an Amazon S3 bucket and send data to Logit.io

--- a/src/pages/log-management/troubleshooting/if-i-reduce-the-retention-on-my-logs-stack-what-happens.mdx
+++ b/src/pages/log-management/troubleshooting/if-i-reduce-the-retention-on-my-logs-stack-what-happens.mdx
@@ -2,6 +2,7 @@
 title: Temporarily Reduce Logs Stack Retention
 metaTitle: Learn How to Temporarily Reduce Logs Stack Retention
 description: Follow Logit.io’s help article to learn about the retention period, how to reduce it, and what happens if you do this
+stackTypes: logs
 ---
 
 # If I reduce the retention on my logs stack temporarily what happens to the indexes?

--- a/src/pages/log-management/troubleshooting/log-volume-count.mdx
+++ b/src/pages/log-management/troubleshooting/log-volume-count.mdx
@@ -2,6 +2,7 @@
 title: Log Volume Count
 metaTitle: Learn How to Check your Log Volume Count
 description: Read Logit.io’s detailed article to learn how to check your Log Management Log Volume count and other usage statistics.
+stackTypes: logs
 ---
 
 # Log Management: Log Volume Count

--- a/src/pages/log-management/troubleshooting/what-is-logitios-policy-on-upgrading.mdx
+++ b/src/pages/log-management/troubleshooting/what-is-logitios-policy-on-upgrading.mdx
@@ -2,6 +2,7 @@
 title: What is Logit.io's Policy on Upgrading ELK
 metaTitle: Learn About Logit.io's Policy on Upgrading ELK
 description: Find out more about Logit.io's policy in regards to automatically upgrading your account's ELK Stack in this help article.
+stackTypes: logs
 ---
 
 # What is Logit.io's policy on upgrading ELK?

--- a/src/pages/opentelemetry/using-opentelemetry-for-logs.mdx
+++ b/src/pages/opentelemetry/using-opentelemetry-for-logs.mdx
@@ -2,6 +2,7 @@
 title: Using OpenTelemetry for Logs
 metaTitle: Learn How to Use OpenTelemetry for Logs
 description: Read our help article to learn how to onboard and get started sending data using OpenTelemetry to your Logs stack
+stackTypes: logs
 ---
 
 # Getting Started With OpenTelemetry for Logs

--- a/src/pages/opentelemetry/using-opentelemetry-for-metrics.mdx
+++ b/src/pages/opentelemetry/using-opentelemetry-for-metrics.mdx
@@ -2,6 +2,7 @@
 title: Using OpenTelemetry for Metrics
 metaTitle: Learn How to Use OpenTelemetry for Metrics
 description: This article walks you through onboarding and getting started sending data using OpenTelemetry to your Metrics Stack in Logit.io
+stackTypes: metrics
 ---
 
 # Getting Started With OpenTelemetry for Metrics

--- a/src/pages/opentelemetry/using-opentelemetry-for-traces.mdx
+++ b/src/pages/opentelemetry/using-opentelemetry-for-traces.mdx
@@ -2,6 +2,7 @@
 title: Using OpenTelemetry for Traces
 metaTitle: Learn How to Use OpenTelemetry for Traces
 description: Follow our in-depth guide to learn how to onboard and get started sending data using OpenTelemetry to your traces/APM stack
+stackTypes: apm
 ---
 
 # Getting Started With OpenTelemetry for Traces


### PR DESCRIPTION
https://logitio.monday.com/boards/806674751/pulses/8202570147

This is to add the stack details to all pages under Logs Management, Infrastructure Metrics, Application Performance Monitoring and OpenTelemetry in the docs.