### PR TITLE
Add dashboard Ids to integrations for installation

### DIFF
--- a/src/pages/account-administration/account-access-users-teams/single-sign-on/okta.mdx
+++ b/src/pages/account-administration/account-access-users-teams/single-sign-on/okta.mdx
@@ -49,7 +49,7 @@ Finally scroll down to the **Assignments** section and click **Allow everyone in
 _Info - Clicking **Allow everyone in your organization to access** means that all users are automatically assigned to the new app without you having to do 
 it for each user manually._
 
-![Add Otka assignments](@/images/sso/okta/okta-assignments.png)
+![Add Okta assignments](@/images/sso/okta/okta-assignments.png)
 
 You will be returned to the **General** tab of the Application. From here copy the **Client ID** and the **Client Secret** to somewhere as they will be 
 required later.

--- a/src/pages/integrations/active-directory.mdx
+++ b/src/pages/integrations/active-directory.mdx
@@ -8,6 +8,7 @@ description: Send your Active Directory Windows Server logs to logit.io via logs
 stackTypes: logs
 sslPortType: beats-ssl
 tags: AD, Active Directory, Windows, Security, LDAP, Authentication, Winlogbeat
+dashboardIds: winlogbeat
 ---
 
 follow these steps to send your Active Directory logs to Logstash and begin searching your data.

--- a/src/pages/integrations/activemq.mdx
+++ b/src/pages/integrations/activemq.mdx
@@ -8,6 +8,7 @@ description: Use Filebeat to send ActiveMQ application logs to your hosted ELK s
 stackTypes: logs, metrics
 sslPortType: beats-ssl
 tags: logs, ActiveMQ, Queue, Message, JMS, Messaging, Activemq, App,Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Prometheus, Messaging, JMS, Message Broker, Java Message Service
+dashboardIds: activemq
 ---
 
 Follow the steps below to ship ActiveMQ logs and metrics to your Logit.io stacks.

--- a/src/pages/integrations/apache-storm.mdx
+++ b/src/pages/integrations/apache-storm.mdx
@@ -8,6 +8,7 @@ description: Utilize the provided instructions to transmit your Apache Storm log
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Apache, Storm, Big Data, Stream Processing
+dashboardIds: apache
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/apache.mdx
+++ b/src/pages/integrations/apache.mdx
@@ -8,6 +8,7 @@ description: Learn how to use Filebeat to send Apache application, access or err
 stackTypes: logs
 sslPortType: beats-ssl
 tags: logs, metrics, Apache, Apache2, HTTP, HTTPD, Web, WebServer, HTTP
+dashboardIds: apache
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/auditbeat.mdx
+++ b/src/pages/integrations/auditbeat.mdx
@@ -8,6 +8,7 @@ description: Send UDP logs to your Logit.io using our example. Auditbeat is an o
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Beats, Logs, Audit, Auditing, Security Logs, Auditbeat
+dashboardIds: auditbeat
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/auditd.mdx
+++ b/src/pages/integrations/auditd.mdx
@@ -7,6 +7,7 @@ description: Configure Filebeat using the pre-defined examples below to start se
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Logs, Audit, Auditing, Security Logs, Auditd
+dashboardIds: auditd
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/aws-eks-logs.mdx
+++ b/src/pages/integrations/aws-eks-logs.mdx
@@ -8,6 +8,7 @@ stackTypes: logs
 description: Send your AWS EKS Logs to logit.io via logstash using the instructions below and begin searching your data
 sslPortType: beats-ssl
 tags: Logs, Amazon, AWS, EKS, Container, Kubernetes, Cloud Logs, Aws Eks Logs
+dashboardIds: aws
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/axonius.mdx
+++ b/src/pages/integrations/axonius.mdx
@@ -8,6 +8,7 @@ description: Send your Axonius logs to logit.io via logstash using the instructi
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Cybersecurity, System, Security Management, Axonius
+dashboardIds: syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/azure-activity-logs.mdx
+++ b/src/pages/integrations/azure-activity-logs.mdx
@@ -7,6 +7,7 @@ color: "#0089d6"
 description: Use Logit.io's Azure Activity Log example configuration to easily forward and send your logs to Logstash and Elasticsearch.
 stackTypes: logs
 tags: Microsoft, Azure, Event Hub, Azure Monitoring, Azure Diagnostics, Azure Monitor, Azure Container, Azure Activity Logs, Cloud Monitoring
+dashboardIds: azure
 ---
 
 In Microsoft Azure the Activity Log is a platform that provides insights into 

--- a/src/pages/integrations/azure-eventhub-diagnostics.mdx
+++ b/src/pages/integrations/azure-eventhub-diagnostics.mdx
@@ -7,7 +7,7 @@ color: "#0089d6"
 description: Follow our Azure Event Hub Diagnostic tutorial to get started shipping Azure Event Hub Diagnostic logs to Logstash for monitoring and analysis.
 stackTypes: logs
 tags: Microsoft, Azure, Event Hub, Cloud Diagnostics, Azure Eventhub Diagnostics
-dashboardIds: azure, dashboardIds: winlogbeat
+dashboardIds: azure
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/azure-eventhub-diagnostics.mdx
+++ b/src/pages/integrations/azure-eventhub-diagnostics.mdx
@@ -7,6 +7,7 @@ color: "#0089d6"
 description: Follow our Azure Event Hub Diagnostic tutorial to get started shipping Azure Event Hub Diagnostic logs to Logstash for monitoring and analysis.
 stackTypes: logs
 tags: Microsoft, Azure, Event Hub, Cloud Diagnostics, Azure Eventhub Diagnostics
+dashboardIds: azure, dashboardIds: winlogbeat
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/azure-kubernetes.mdx
+++ b/src/pages/integrations/azure-kubernetes.mdx
@@ -8,6 +8,7 @@ description: Follow our Azure Kubernetes Container tutorial to get started shipp
 stackTypes: logs, metrics
 sslPortType: beats-ssl
 tags: Logs, Filebeat, Kubernetes, K8s, AKS, Azure, Azure Kubernetes, Cloud Logs, Azure Kubernetes Logs, Metrics, Metricbeat, Stats, Container Orchestration, Module
+dashboardIds: azure
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/azure-sql.mdx
+++ b/src/pages/integrations/azure-sql.mdx
@@ -7,6 +7,7 @@ color: "#0089d6"
 description: Follow our Azure SQL tutorial to pull logs from Azure Event Hub to Logstash and begin with Azure Application logging.
 stackTypes: logs
 tags: Microsoft, Azure, Event Hub, SQL, Database, Cloud Database, Azure Sql
+dashboardIds: azure
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/azure.mdx
+++ b/src/pages/integrations/azure.mdx
@@ -7,6 +7,7 @@ color: "#0089d6"
 description: Send your Azure application/access/error logs to logit.io via logstash using the instructions below and begin searching your data
 stackTypes: logs
 tags: Microsoft, Azure, Event Hub, Cloud Services
+dashboardIds: azure
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/bunny-net.mdx
+++ b/src/pages/integrations/bunny-net.mdx
@@ -8,6 +8,7 @@ description: Use our example to configure Filebeat to ship bunny.net content del
 stackTypes: logs
 sslPortType: beats-ssl
 tags: bunny.net, bunny.net content delivery, content delivery network, cdn, syslog, beats, logs, filebeat, file ,files, text, Bunny Net
+dashboardIds: syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/centos.mdx
+++ b/src/pages/integrations/centos.mdx
@@ -9,6 +9,7 @@ description: Use Filebeat to send Centos logs to your ELK stacks. Configure File
 stackTypes: logs
 sslPortType: beats-ssl
 tags: logs, centos, linux, Centos
+dashboardIds: syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/checkpoint.mdx
+++ b/src/pages/integrations/checkpoint.mdx
@@ -7,6 +7,7 @@ color: "#E0005A"
 description: Follow our Checkpoint tutorial to get started sending Checkpoint logs to Logstash for monitoring and analysis.
 stackTypes: logs
 tags: Logs, Checkpoint, Firewall, Security Logs
+dashboardIds: syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/cisco-asa.mdx
+++ b/src/pages/integrations/cisco-asa.mdx
@@ -8,6 +8,7 @@ description: Use our example to configure Filebeat to ship Cisco logs to Logstas
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Beats, Logs, Filebeat, Cisco, ASA, Firewall, Security Logs, Cisco Asa
+dashboardIds: cisco
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/cisco-firepower.mdx
+++ b/src/pages/integrations/cisco-firepower.mdx
@@ -9,6 +9,7 @@ description: How to send Cisco Firepower logs to your Hosted ELK Logstash instan
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Cisco, Firepower, Firewall, Syslog, Beats, Logs, Filebeat, File, Text, Security Logs, Cisco Firepower
+dashboardIds: cisco
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/cisco-meraki.mdx
+++ b/src/pages/integrations/cisco-meraki.mdx
@@ -9,6 +9,7 @@ description: How to send Cisco Meraki logs to your Hosted ELK Logstash instance.
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Cisco, Meraki, Firewall, Syslog, Beats, Logs, Filebeat, File, Text, Security Logs, Cisco Meraki
+dashboardIds: cisco, syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/cloudfoundry.mdx
+++ b/src/pages/integrations/cloudfoundry.mdx
@@ -9,6 +9,7 @@ stackTypes: logs
 portType: tcp
 sslPortType: tcp-ssl
 tags: Logs, Cloud Foundry, Cloudfoundry, VMware, VMware Tanzu, BOSH, Pivotal, Log Drain, Cloud Logs
+dashboardIds: syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/cloudtrail.mdx
+++ b/src/pages/integrations/cloudtrail.mdx
@@ -7,6 +7,7 @@ color: "#689e2f"
 stackTypes: logs
 description: Learn how to send CloudTrail logs to your ELK Logstash instance with our configuration guide. Simplify sending logs with Logit.io's source configurations.
 tags: Logs, AWS, Amazon, Cloudtrail, S3, Cloud Logs
+dashboardIds: aws
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/cynet.mdx
+++ b/src/pages/integrations/cynet.mdx
@@ -8,6 +8,7 @@ description: Send your Cynet logs to logit.io via Logstash using the instruction
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Cybersecurity, System, Security Management, Cynet
+dashboardIds: syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/debian.mdx
+++ b/src/pages/integrations/debian.mdx
@@ -8,6 +8,7 @@ description: Use Filebeat to send Debian application, access and system logs to 
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Logs, Debian, Linux, Operating System Logs
+dashboardIds: syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/digital-ocean.mdx
+++ b/src/pages/integrations/digital-ocean.mdx
@@ -9,6 +9,7 @@ description: Learn how to forward logs from your DigitalOcean droplets and Kuber
 stackTypes: logs
 sslPortType: Syslog-SSL
 tags: DigitalOcean, Logs, Syslog, Centralized Logging, Kubernetes, Droplets, Cloud Computing, Monitoring
+dashboardIds: syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/elasticsearch.mdx
+++ b/src/pages/integrations/elasticsearch.mdx
@@ -8,6 +8,7 @@ description: Filebeat allows you to send logs to your ELK stacks. Configure File
 stackTypes: logs, metrics
 sslPortType: beats-ssl
 tags: Logs, Logstash, Elasticsearch, Beats, Filebeat, Files, Log Files, Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Prometheus, Search, NoSQL
+dashboardIds: kafka
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/eset.mdx
+++ b/src/pages/integrations/eset.mdx
@@ -8,6 +8,7 @@ description: Send your ESET logs to logit.io via logstash using the instructions
 stackTypes: logs
 sslPortType: beats-ssl
 tags: ESET, Firewall, SIEM, Cybersecurity, Security, Network Security, Eset
+dashboardIds: syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/fastly.mdx
+++ b/src/pages/integrations/fastly.mdx
@@ -8,6 +8,7 @@ description: Send your Fastly application/access/error logs to logit.io via logs
 stackTypes: logs
 sslPortType: syslog-ssl
 tags: Logs, Fastly
+dashboardIds: syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/filebeat-system.mdx
+++ b/src/pages/integrations/filebeat-system.mdx
@@ -8,6 +8,7 @@ description: Filebeat allows you to send system logs to your ELK stacks. Configu
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Beats, Logs, Filebeat, System, Syslog, Auth, Authentication Logs, Filebeat System
+dashboardIds: netflow, syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/filebeat.mdx
+++ b/src/pages/integrations/filebeat.mdx
@@ -9,6 +9,7 @@ description: Filebeat allows you to send logs to your ELK stacks. Configure File
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Beats, Logs, Filebeat, File, Files, Text, Log Files
+dashboardIds: netflow
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/fortigate.mdx
+++ b/src/pages/integrations/fortigate.mdx
@@ -9,6 +9,7 @@ description: Use our example to configure Filebeat to ship Fortigate firewall lo
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Fortigate, Firewall, Syslog, Beats, Logs, Filebeat, File, Text, Security Logs
+dashboardIds: syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/gitlabs.mdx
+++ b/src/pages/integrations/gitlabs.mdx
@@ -8,6 +8,7 @@ description: Use our example to configure Filebeat to ship GitLab logs to your L
 stackTypes: logs
 sslPortType: beats-ssl
 tags: GitLab, DevOps, Syslog, Beats, Logs, Filebeat, File, Text, Log Files, Gitlabs
+dashboardIds: syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/google-cloud-compute-engine.mdx
+++ b/src/pages/integrations/google-cloud-compute-engine.mdx
@@ -7,6 +7,7 @@ color: "#205bb0"
 description: Follow our Google Compute Engine tutorial to get started shipping Google Compute Engine logs to Logstash for monitoring and analysis in Logit.io.
 stackTypes: logs, metrics
 tags: Logs, Google, GCE, Stack Driver, GKE, Stackdriver, Google Compute Engine, GCP, Cloud Compute, Googlecloudcompute, Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Virtual Machine, VM
+dashboardIds: gcp
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/google-cloud-load-balancing.mdx
+++ b/src/pages/integrations/google-cloud-load-balancing.mdx
@@ -7,6 +7,7 @@ color: "#205bb0"
 description: Follow our configuration and setup example to get started with shipping Google Cloud Load Balancing logs to Lostash for monitoring and analysis in Logit.io. 
 stackTypes: logs, metrics
 tags: Logs, Google, GCE, Stack Driver, GKE, Stackdriver, Google Cloud Load Balancing, GCP, Compute, Googlecloudloadbalancing, Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Traffic Balancing, Load Balancer
+dashboardIds: gcp
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/google-cloud-operations.mdx
+++ b/src/pages/integrations/google-cloud-operations.mdx
@@ -7,6 +7,7 @@ color: "#205bb0"
 description: Learn how to send Google Cloud Platform logs to your Logstash instance - Ship over 100 log data types fast with Logit.io & simplify your log analysis.
 stackTypes: logs
 tags: Logs, Google, GCE, Stack Driver, GKE, Stackdriver, Google Cloud Platform, GCP, Google Operations, Cloud Operations, Googlecloudplatform
+dashboardIds: gcp
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/google-cloud-run.mdx
+++ b/src/pages/integrations/google-cloud-run.mdx
@@ -7,6 +7,7 @@ color: "#205bb0"
 description: Learn how to send Google Cloud Cloud Run logs and metrics to your Logit.io & simplify your analysis.
 stackTypes: logs, metrics
 tags: Logs, Google, GCE, Stack Driver, GKE, Stackdriver, Google Cloud Run, GCP, Cloud Compute, Cloud Run, Telegraf, Metrics, Telemetry, OpenTelemetry, Instrumentation, Containerization, Containers
+dashboardIds: gcp
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/google-cloud-storage-audit.mdx
+++ b/src/pages/integrations/google-cloud-storage-audit.mdx
@@ -7,6 +7,7 @@ color: "#205bb0"
 description: Learn how to send Google Cloud Storage audit logs to your Logstash instance & simplify your log analysis.
 stackTypes: logs
 tags: Logs, Google, GCE, Stack Driver, GKE, Stackdriver, Google Cloud Storage, GCP, GCS, Googlecloudstorage
+dashboardIds: gcp
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/haproxy.mdx
+++ b/src/pages/integrations/haproxy.mdx
@@ -8,6 +8,7 @@ description: Use Filebeat to send HAProxy application, access or error logs to y
 stackTypes: logs, metrics
 sslPortType: beats-ssl
 tags: Logs, HAProxy, Proxy, Load Balancer, Ingress, HTTP, Web Server, Web Traffic, Haproxy, Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation
+dashboardIds: haproxy, syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/heartbeat.mdx
+++ b/src/pages/integrations/heartbeat.mdx
@@ -9,6 +9,7 @@ description: Get started with sending your log data from Heartbeat to Logstash u
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Beats, Logs, Monitoring, Healthcheck, Heartbeat
+dashboardIds: heartbeat
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/iis.mdx
+++ b/src/pages/integrations/iis.mdx
@@ -9,6 +9,7 @@ description: Get started with analysing IIS logs with our easy integration allow
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Logs, IIS, Microsoft, Windows, HTTP, Web, Web Server, Internet Information Services, .NET Framework, Iis
+dashboardIds: iis
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/junipersrx.mdx
+++ b/src/pages/integrations/junipersrx.mdx
@@ -9,6 +9,7 @@ description: Use our example to configure Filebeat to ship Juniper SRX firewall 
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Juniper SRX, Firewall, Syslog, Beats, Logs, Filebeat, Files, Text, Junipersrx
+dashboardIds: syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/kafka-message-queue.mdx
+++ b/src/pages/integrations/kafka-message-queue.mdx
@@ -8,6 +8,7 @@ description: Use Filebeat to send Kafka MQ topics to your hosted ELK stacks. Con
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Logs, Apache Kafka, Kafka MQ, Message Queue
+dashboardIds: kafka
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/kafka.mdx
+++ b/src/pages/integrations/kafka.mdx
@@ -8,6 +8,7 @@ description: Use our example to configure Filebeat to send your Apache Kafka app
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Logs, Apache Kafka, App
+dashboardIds: kafka
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/keycdn.mdx
+++ b/src/pages/integrations/keycdn.mdx
@@ -8,6 +8,7 @@ description: Learn how to ship KeyCDN logs to your Hosted ELK Logstash instance 
 stackTypes: logs
 portType: syslog
 tags: Logs, KeyCDN, CDN, Content Delivery Network, Keycdn
+dashboardIds: syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/kong.mdx
+++ b/src/pages/integrations/kong.mdx
@@ -8,6 +8,7 @@ description: Send your kong application/access/error logs to Logit.io via Logsta
 stackTypes: logs
 sslPortType: tcp-ssl
 tags: Logs, Kong, Nginx, Service Mesh
+dashboardIds: nginx
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/logstash-logging.mdx
+++ b/src/pages/integrations/logstash-logging.mdx
@@ -9,6 +9,7 @@ description: Filebeat allows you to send logs to your ELK stacks. Configure File
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Logs, Logstash, Elasticsearch, Beats, Filebeat, File, Logging
+dashboardIds: logstash
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/logstash.mdx
+++ b/src/pages/integrations/logstash.mdx
@@ -9,6 +9,7 @@ description: Learn how to get started with logging and send data from your local
 stackTypes: logs
 sslPortType: tcp-ssl
 tags: Logs, Metrics, Logstash, Elasticsearch, JSON
+dashboardIds: logstash
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/macos.mdx
+++ b/src/pages/integrations/macos.mdx
@@ -9,6 +9,7 @@ description: Use Filebeat to send macOS logs to your ELK stacks. Configure Fileb
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Logs, Mac, Apple, OSX, Mojave, MacOS, Macos
+dashboardIds: syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/mcafee-epo.mdx
+++ b/src/pages/integrations/mcafee-epo.mdx
@@ -9,6 +9,7 @@ description: Send your McAfee EPO Logs to logit.io via logstash using the instru
 stackTypes: logs
 sslPortType: syslog-ssl
 tags: Logs, McAfee, Syslog, Mcafee Epo
+dashboardIds: syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/microsoft365.mdx
+++ b/src/pages/integrations/microsoft365.mdx
@@ -8,6 +8,7 @@ description: Use our example to configure Filebeat to ship Microsoft 365 logs to
 stackTypes: logs
 sslPortType: beats-ssl
 tags: M365, O365, Microsoft, Microsoft 365, Syslog, Beats, Logs, Filebeat, Files, Text, Microsoft365
+dashboardIds: o365
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/mongodb.mdx
+++ b/src/pages/integrations/mongodb.mdx
@@ -8,6 +8,7 @@ description: Discover the process of transmitting MongoDB logs to your Logstash 
 stackTypes: logs, metrics
 sslPortType: beats-ssl
 tags: Logs, MongoDB, Database, NoSQL, DB, Mongodb, Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation
+dashboardIds: mongodb
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/mysql.mdx
+++ b/src/pages/integrations/mysql.mdx
@@ -9,6 +9,7 @@ description: Use Filebeat to send MySQL slow query and error logs to your ELK st
 stackTypes: logs, metrics
 sslPortType: beats-ssl
 tags: Logs, Metrics, Database, DB, MySQL, RDBMS, Mysql, Telegraf, Telemetry, OpenTelemetry, Health, Instrumentation
+dashboardIds: mysql
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/nginx.mdx
+++ b/src/pages/integrations/nginx.mdx
@@ -8,6 +8,7 @@ description: Use our example to configure Telegraf to ship Nginx metrics to your
 stackTypes: logs, metrics
 sslPortType: beats-ssl
 tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Nginx, Web Server, Monitoring, Performance
+dashboardIds: nginx
 ---
 
 Following this guide will enable you to ship Nginx logs and metrics to your Logit.io stack.

--- a/src/pages/integrations/packetbeat.mdx
+++ b/src/pages/integrations/packetbeat.mdx
@@ -9,6 +9,7 @@ description: Packetbeat setup and example configuration for sending logs to the 
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Beats, Logs, Network, Packet, Traffic, Network Monitoring, Network Analysis, Packet Capture, Packetbeat
+dashboardIds: mongodb, mysql, redis
 ---
 
 Packetbeat is a network package analyser used to capture network traffic. It can be used to extract useful fields of information from network transactions 

--- a/src/pages/integrations/packetbeat.mdx
+++ b/src/pages/integrations/packetbeat.mdx
@@ -9,7 +9,7 @@ description: Packetbeat setup and example configuration for sending logs to the 
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Beats, Logs, Network, Packet, Traffic, Network Monitoring, Network Analysis, Packet Capture, Packetbeat
-dashboardIds: mongodb, mysql, redis
+dashboardIds: packetbeat, mongodb, mysql, redis
 ---
 
 Packetbeat is a network package analyser used to capture network traffic. It can be used to extract useful fields of information from network transactions 

--- a/src/pages/integrations/palo-alto-networks.mdx
+++ b/src/pages/integrations/palo-alto-networks.mdx
@@ -9,6 +9,7 @@ description: Use our example to configure Filebeat to ship Palo Alto Networks fi
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Palo Alto, Palo Alto Networks, Firewall, Syslog, Beats, Logs, Filebeat, Files, Text, Network Security, Cybersecurity, Palo Alto Networks
+dashboardIds: panw, syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/pfsense.mdx
+++ b/src/pages/integrations/pfsense.mdx
@@ -9,6 +9,7 @@ description: Use our example to configure Filebeat to ship pfSense firewall logs
 stackTypes: logs
 sslPortType: beats-ssl
 tags: pfSense, Firewall, Syslog, Beats, Logs, Filebeat, Files, Text, Network Security, Cybersecurity, Pfsense
+dashboardIds: panw, syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/postgresql.mdx
+++ b/src/pages/integrations/postgresql.mdx
@@ -8,6 +8,7 @@ description: How to send PostgreSQL logs to your Hosted ELK Logstash instance. C
 stackTypes: logs, metrics
 sslPortType: beats-ssl
 tags: Logs, Database, DB, PostgreSQL, RDBMS, SQL, Postgresql, Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Monitoring, Database Management
+dashboardIds: postgresql
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/redhat.mdx
+++ b/src/pages/integrations/redhat.mdx
@@ -9,6 +9,7 @@ description: Use Filebeat to send Red Hat application, access and system logs to
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Logs, RedHat, Red Hat, RHEL, Fedora, Linux Distribution, Redhat
+dashboardIds: syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/redis.mdx
+++ b/src/pages/integrations/redis.mdx
@@ -8,6 +8,7 @@ description: Find the process of sending Redis application logs to your Logstash
 stackTypes: logs, metrics
 sslPortType: beats-ssl
 tags: Logs, Redis, NoSQL, In-Memory Database, App, Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Database, Monitoring
+dashboardIds: redis
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/s3.mdx
+++ b/src/pages/integrations/s3.mdx
@@ -8,6 +8,7 @@ color: "#e9463c"
 stackTypes: logs
 description: Send your Amazon S3 application/access/error logs to logit.io via logstash using the instructions below and begin searching your data
 tags: Logs, S3, AWS, Amazon, Cloud Storage
+dashboardIds: aws
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/sentinelone.mdx
+++ b/src/pages/integrations/sentinelone.mdx
@@ -8,6 +8,7 @@ description: Send your SentinelOne logs to logit.io via logstash using the instr
 stackTypes: logs
 sslPortType: beats-ssl
 tags: SentinelOne, Sentinel One, SIEM, Cyber-Security, Security, Network, Endpoint Security, Sentinelone
+dashboardIds: syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/solaris.mdx
+++ b/src/pages/integrations/solaris.mdx
@@ -9,6 +9,7 @@ description: Follow our installation guide for Oracle Solaris logs to get starte
 stackTypes: logs
 sslPortType: syslog-ssl
 tags: Logs, Solaris, Sun, Oracle, Syslog, Unix
+dashboardIds: syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/sonic-wall.mdx
+++ b/src/pages/integrations/sonic-wall.mdx
@@ -9,6 +9,7 @@ description: How to send SonicWall logs to your Hosted ELK Logstash instance. Co
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Logs, Network Security, Cybersecurity, Sonic, Wall
+dashboardIds: syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/sql-server.mdx
+++ b/src/pages/integrations/sql-server.mdx
@@ -8,6 +8,7 @@ description: Use our example to configure Telegraf to ship SQL Server metrics to
 stackTypes: metrics
 sslPortType: beats-ssl
 tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, SQL Server, Database, Monitoring, Sql
+dashboardIds: mysql
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/stormshield.mdx
+++ b/src/pages/integrations/stormshield.mdx
@@ -8,6 +8,7 @@ description: Send your Stormshield logs to logit.io via Logstash using the instr
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Storm Shield, SIEM, Cyber-Security, Security, Stormshield
+dashboardIds: syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/suricata.mdx
+++ b/src/pages/integrations/suricata.mdx
@@ -7,6 +7,7 @@ description: Use our example to configure Telegraf to ship Suricata metrics to y
 stackTypes: metrics
 sslPortType: beats-ssl
 tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Suricata, Network Security, Monitoring
+dashboardIds: suricata
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/syslog-ng.mdx
+++ b/src/pages/integrations/syslog-ng.mdx
@@ -9,6 +9,7 @@ stackTypes: logs
 sslPortType: syslog-ssl
 portType: syslog
 tags: Logs, Rsyslog, Linux, Syslogd, Logging, Syslog Ng
+dashboardIds: syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/syslog.mdx
+++ b/src/pages/integrations/syslog.mdx
@@ -9,6 +9,7 @@ stackTypes: logs
 sslPortType: syslog-ssl
 portType: syslog
 tags: Logs, Syslog, Rsyslog, Linux, Syslogd, Logging
+dashboardIds: syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/sysmon.mdx
+++ b/src/pages/integrations/sysmon.mdx
@@ -9,6 +9,7 @@ description: Learn how to use Winlogbeat to send Sysmon event logs to your ELK s
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Logs, System Monitor, Sysmon, Microsoft Sysinternals, Windows Event Logging, Security Monitoring, Windows Event Log, Windows Security, Winlogbeat
+dashboardIds: winlogbeat
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/tengine.mdx
+++ b/src/pages/integrations/tengine.mdx
@@ -8,6 +8,7 @@ description: Use our example to configure Telegraf to ship Tengine metrics to yo
 stackTypes: metrics
 sslPortType: beats-ssl
 tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Tengine, Web Server
+dashboardIds: nginx
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/traefik.mdx
+++ b/src/pages/integrations/traefik.mdx
@@ -8,6 +8,7 @@ description: Learn how to send Traefik access logs to your Logstash instance usi
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Logs, Traefik, Web Server, Ingress Controller
+dashboardIds: traefik
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/ubuntu.mdx
+++ b/src/pages/integrations/ubuntu.mdx
@@ -9,6 +9,7 @@ description: Follow our configuration guide to send Ubuntu system logs and get s
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Logs, Ubuntu, System, Linux, Operating System
+dashboardIds: syslog
 ---
 
 Follow the steps below to send your observability data to Logit.io

--- a/src/pages/integrations/windows.mdx
+++ b/src/pages/integrations/windows.mdx
@@ -9,6 +9,7 @@ description: Send your Windows application/access/error logs to Logit.io via Win
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Logs, Windows, Microsoft, System, Event Log, Operating System, Winlogbeat
+dashboardIds: winlogbeat
 ---
 
 Winlogbeat is a Windows specific event-log shipping agent installed 

--- a/src/pages/integrations/zeek.mdx
+++ b/src/pages/integrations/zeek.mdx
@@ -7,6 +7,7 @@ description: Use our example to configure Filebeat to ship Zeek logs to your Log
 stackTypes: logs
 sslPortType: beats-ssl
 tags: Zeek, Open Source, Firewall, Network Analysis, Security, Logs, Filebeat, Text Logs
+dashboardIds: zeek
 ---
 
 Follow the steps below to send your observability data to Logit.io


### PR DESCRIPTION
https://logitio.monday.com/boards/806674751/pulses/8740941118

This PR is to add dashboard Id's to the the integrations on the docs site.

This is based on the dashboards found in RavenDb under KibanaDashboards.

Further information about the dashboards can be found here:
https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-modules.html

I was unable to match up the following dashboards with an integration:

coredns
envoyproxy
ibmmq
icinga
iptables 
microsoft
misp (depricated)
nats
otka
osquery
pensando
santa
system
threatintel
