### PR TITLE
Getting started meta update so that Grafana Dashboards appears correctly

### DIFF
--- a/src/pages/getting-started/_meta.json
+++ b/src/pages/getting-started/_meta.json
@@ -11,5 +11,6 @@
   "monitoring-an-application": "Monitoring an Application",
   "opentelemetry": "Opentelemetry",
   "telegraf": "Telegraf",
-  "opensearch-dashboards": "OpenSearch Dashboards"
+  "opensearch-dashboards": "OpenSearch Dashboards",
+  "grafana-dashboards": "Grafana Dashboards"
 }


### PR DESCRIPTION
This is a correction to the meta file so that the Grafana Dashboards page appears correctly in the side menu under Getting Started.