### PR TITLE
fixed indenting in the code snippet - need to confirm that the traili…

### DIFF
--- a/src/pages/integrations/otel-collector.mdx
+++ b/src/pages/integrations/otel-collector.mdx
@@ -56,7 +56,7 @@ The OpenTelemetry Collector allows you to send logs, metrics and traces to your 
 
   Copy the configuration file below (making the above changes if necessary) and overwrite the contents of otelcol-config.yml (this file can be found in the otelcollector folder where you installed the OpenTelemetry Collector demo application e.g. opentelemetry-demo/src/otelcollector/otelcol-config.yml).
 
-    ```yaml copy showLineNumbers /@opentelemetry.username:strip_quotes/ /@opentelemetry.password:strip_quotes/ /@elasticsearch.username:strip_quotes/ /@elasticsearch.password:strip_quotes/ /@logs_id-es.logit.io/ /@metricsUsername/ /@metricsPassword/ /metrics_id-vm.logit.io/ /@vmAgentPort/ /@opentelemetry.endpointAddress:strip_quotes/ /@opentelemetry.grpcPort:strip_quotes/
+  ```yaml copy showLineNumbers /@opentelemetry.username:strip_quotes/ /@opentelemetry.password:strip_quotes/ /@elasticsearch.username:strip_quotes/ /@elasticsearch.password:strip_quotes/ /@logs_id-es.logit.io/ /@metricsUsername/ /@metricsPassword/ /metrics_id-vm.logit.io/ /@vmAgentPort/ /@opentelemetry.endpointAddress:strip_quotes/ /@opentelemetry.grpcPort:strip_quotes/
   extensions:
     basicauth/apm:
       client_auth:
@@ -91,7 +91,7 @@ The OpenTelemetry Collector allows you to send logs, metrics and traces to your 
     otlp:
       auth:
         authenticator: basicauth/apm
-      endpoint: '@opentelemetry.endpointAddress:strip_quotes:@opentelemetry.grpcPort'
+      endpoint: '@opentelemetry.endpointAddress:strip_quotes:@opentelemetry.grpcPort:strip_quotes'
     logging:
       verbosity: detailed
   service:


### PR DESCRIPTION
…ng quote on the apm url doesn't get removed when templated

Could someone please confirm that when inserting stack details it no longer removes the trailing quote on the APM endpoint?

The current behaviour of the live docs is as follows
```
otlp:
  auth:
    authenticator: basicauth/apm
  endpoint: '<your-otel-endpoint-address>:<your-otel-endpoint-grpc-port>'
```

becomes

```
otlp:
  auth:
    authenticator: basicauth/apm
  endpoint: 'asjkhdaskhjadshkadskjhads-apm.logit.io:1234
```