### PR TITLE
Docs: Hosted OpenSearch MCP on Log Management plans

### DIFF
--- a/src/pages/developer-api/alerting-via-api.mdx
+++ b/src/pages/developer-api/alerting-via-api.mdx
@@ -10,7 +10,7 @@ Manage alerting for your Logs and Infrastructure Metrics stacks via the Logit.io
 
 For an overview of alerting concepts, see [Log Management Alerting](/log-management/alerting/overview) and [Infrastructure Metrics Alerting](/infrastructure-metrics/alerting/overview).
 
-Use your Dashboard API key from the [Profile](https://dashboard.logit.io/profile) page in the `x-api-key` header. See [Authentication](/developer-api/authentication) for setup and security. Use `@logs_id` for Log stacks and `@metrics_id` for Metrics stacks (from your session/JWT when signed in).
+Use your Dashboard API key from the [Profile](https://dashboard.logit.io/profile) page in the `x-api-key` header. See [Authentication](/developer-api/authentication) for setup and security. Use `@logs_id` for Log stacks and `@metrics_id` for Metrics stacks (auto-filled when signed in).
 
 ## Enable or Disable Alerting
 

--- a/src/pages/developer-api/ingestion-statistics.mdx
+++ b/src/pages/developer-api/ingestion-statistics.mdx
@@ -8,7 +8,7 @@ description: Get ingestion event, history, latency, metrics, and span statistics
 
 Retrieve ingestion statistics for your stacks using the Logit.io Developer API. These endpoints provide visibility into data flow, throughput, and latency for Logs, Infrastructure Metrics, and Application Performance Monitoring products.
 
-Use your Dashboard API key from the [Profile](https://dashboard.logit.io/profile) page in the `x-api-key` header. See [Authentication](/developer-api/authentication) for setup and security. Use `@logs_id`, `@metrics_id`, or `@apm_id` depending on your stack type (from your session/JWT when signed in).
+Use your Dashboard API key from the [Profile](https://dashboard.logit.io/profile) page in the `x-api-key` header. See [Authentication](/developer-api/authentication) for setup and security. Use `@logs_id`, `@metrics_id`, or `@apm_id` depending on your stack type (auto-filled when signed in).
 
 ## Log Stack: Ingestion Events
 

--- a/src/pages/developer-api/managing-stacks.mdx
+++ b/src/pages/developer-api/managing-stacks.mdx
@@ -8,7 +8,7 @@ description: List stacks, get connection details, and manage upgrades using the 
 
 Automate stack management using the Logit.io Developer API. This guide covers listing stacks, retrieving connection details, and requesting upgrades.
 
-Use your Dashboard API key from the [Profile](https://dashboard.logit.io/profile) page in the `x-api-key` header. See [Authentication](/developer-api/authentication) for setup and security. For stack-specific endpoints, use `@logs_id`, `@metrics_id`, or `@apm_id` depending on which stack you're managing (from your session/JWT when signed in).
+Use your Dashboard API key from the [Profile](https://dashboard.logit.io/profile) page in the `x-api-key` header. See [Authentication](/developer-api/authentication) for setup and security. For stack-specific endpoints, use `@logs_id`, `@metrics_id`, or `@apm_id` depending on which stack you're managing (auto-filled when signed in).
 
 ## List Your Stacks
 

--- a/src/pages/developer-api/overview.mdx
+++ b/src/pages/developer-api/overview.mdx
@@ -13,7 +13,7 @@ The Logit.io Developer API (control-plane API) lets you programmatically manage 
 - **Base URL:** `https://dashboard.logit.io`
 - **Authentication:** All endpoints require a Logit.io API user key, passed in the `x-api-key` header.
 
-When you are signed in and have Dashboard API keys, the docs replace `@dashboardApiKey` in the examples below with your first key so you can copy and run the request. When unauthenticated or without keys, it shows `<your-dashboard-api-key>`. Stack-scoped examples use `@logs_id`, `@metrics_id`, or `@apm_id` depending on stack type (Logs, Metrics, APM), replaced from your session (JWT) when signed in, or `<your-stack-id>` otherwise. Get your API key from the [Profile](https://dashboard.logit.io/profile) page; see [Authentication](/developer-api/authentication) for setup and security.
+When you are signed in and have Dashboard API keys, the docs replace `@dashboardApiKey` in the examples below with your first key so you can copy and run the request. When unauthenticated or without keys, it shows `<your-dashboard-api-key>`. Stack-scoped examples use `@logs_id`, `@metrics_id`, or `@apm_id` depending on stack type (Logs, Metrics, APM), auto-filled when signed in, or `<your-stack-id>` otherwise. Get your API key from the [Profile](https://dashboard.logit.io/profile) page; see [Authentication](/developer-api/authentication) for setup and security.
 
 Example request:
 

--- a/src/pages/developer-api/pipeline-configuration.mdx
+++ b/src/pages/developer-api/pipeline-configuration.mdx
@@ -10,7 +10,7 @@ Automate Logstash pipeline management for your Log stack using the Logit.io Deve
 
 For background on ingestion pipelines, see [Log Management Ingestion Pipeline](/log-management/ingestion-pipeline/overview).
 
-Use your Dashboard API key from the [Profile](https://dashboard.logit.io/profile) page in the `x-api-key` header. See [Authentication](/developer-api/authentication) for setup and security. Examples use `@logs_id` for your Log stack (from your session/JWT when signed in).
+Use your Dashboard API key from the [Profile](https://dashboard.logit.io/profile) page in the `x-api-key` header. See [Authentication](/developer-api/authentication) for setup and security. Examples use `@logs_id` for your Log stack (auto-filled when signed in).
 
 ## Get Pipeline Configuration
 

--- a/src/pages/developer-api/security-and-diagnostics.mdx
+++ b/src/pages/developer-api/security-and-diagnostics.mdx
@@ -8,7 +8,7 @@ description: Retrieve firewall rules and diagnostic logs for your Log stacks.
 
 Retrieve security (firewall) rules and diagnostic logs for your Log stacks using the Logit.io Developer API. Use these endpoints to audit configuration, troubleshoot pipeline issues, and integrate with monitoring tools.
 
-Use your Dashboard API key from the [Profile](https://dashboard.logit.io/profile) page in the `x-api-key` header. See [Authentication](/developer-api/authentication) for setup and security. Examples use `@logs_id` for your Log stack (from your session/JWT when signed in).
+Use your Dashboard API key from the [Profile](https://dashboard.logit.io/profile) page in the `x-api-key` header. See [Authentication](/developer-api/authentication) for setup and security. Examples use `@logs_id` for your Log stack (auto-filled when signed in).
 
 ## Get Firewall Rules
 

--- a/src/pages/log-management/opensearch/rest-api.mdx
+++ b/src/pages/log-management/opensearch/rest-api.mdx
@@ -18,7 +18,7 @@ The complete reference lives in **[OpenSearch REST API](/opensearch-api)** — s
 
 - **Stack OpenSearch REST API** — query, index, and manage data on `{stack-id}-es.logit.io` ([guides below](/opensearch-api))
 - [OpenSearch API (user credentials)](/opensearch-api/user-credentials) — per-user / service-account Basic auth on `{stack-id}-es-user.logit.io` (Business / Custom)
-- [Hosted OpenSearch MCP](/opensearch-api/hosted-mcp) — read-only Cursor / Claude at `{stack-id}-mcp.logit.io` (Business / Custom)
+- [Hosted OpenSearch MCP](/opensearch-api/hosted-mcp) — read-only Cursor / Claude at `{stack-id}-mcp.logit.io` (Log Management and Custom)
 - [OpenSearch Dashboards REST API](/log-management/opensearch/opensearch-dashboards/api) — Dashboards features via `kibana.logit.io` and Profile proxy credentials
 - [Logit Developer API](/developer-api/overview) — account and stack management via `dashboard.logit.io/api`
 </Callout>

--- a/src/pages/opensearch-api/connect.mdx
+++ b/src/pages/opensearch-api/connect.mdx
@@ -23,7 +23,7 @@ When signed in, examples auto-fill `@opensearch.endpointAddress`, `@opensearch.a
 | **User credentials** | `{stack-id}-es-user.logit.io` | **Different** Profile or service-account username/password (not the stack key) | [OpenSearch API (user credentials)](/opensearch-api/user-credentials) |
 | **Hosted MCP** | `{stack-id}-mcp.logit.io` | **Different** dedicated MCP username + MCP API key | [Hosted OpenSearch MCP](/opensearch-api/hosted-mcp) |
 
-User credentials and hosted MCP require a **Business** or **Custom** plan and must be enabled per stack under **Settings → Access**. Docs JWT placeholders for those endpoints are filled only when the feature is enabled (and, for `-es-user`, when you have opted in from Profile).
+User credentials require a **Business** or **Custom** plan. Hosted MCP is available on **Log Management** and **Custom** plans. Both must be enabled per stack under **Settings → Access**. Docs JWT placeholders for those endpoints are filled only when the feature is enabled (and, for `-es-user`, when you have opted in from Profile).
 
 ### Which stack type do you have?
 

--- a/src/pages/opensearch-api/connect.mdx
+++ b/src/pages/opensearch-api/connect.mdx
@@ -23,7 +23,7 @@ When signed in, examples auto-fill `@opensearch.endpointAddress`, `@opensearch.a
 | **User credentials** | `{stack-id}-es-user.logit.io` | **Different** Profile or service-account username/password (not the stack key) | [OpenSearch API (user credentials)](/opensearch-api/user-credentials) |
 | **Hosted MCP** | `{stack-id}-mcp.logit.io` | **Different** dedicated MCP username + MCP API key | [Hosted OpenSearch MCP](/opensearch-api/hosted-mcp) |
 
-User credentials require a **Business** or **Custom** plan. Hosted MCP is available on **Log Management** and **Custom** plans. Both must be enabled per stack under **Settings → Access**. Docs JWT placeholders for those endpoints are filled only when the feature is enabled (and, for `-es-user`, when you have opted in from Profile).
+User credentials require a **Business** or **Custom** plan. Hosted MCP is available on **Log Management** and **Custom** plans. Enable each applicable method independently under **Settings → Access**.
 
 ### Which stack type do you have?
 

--- a/src/pages/opensearch-api/hosted-mcp.mdx
+++ b/src/pages/opensearch-api/hosted-mcp.mdx
@@ -102,7 +102,7 @@ Claude Desktop uses the same JSON shape. Paste the config from **Settings → En
 | **404 / connection failed** | MCP enabled on the stack? URL exact (`@mcp.endpointAddress`)? DNS may take a short time after enable. |
 | **Client cannot list tools** | Confirm the client supports remote MCP over HTTPS with custom headers; re-paste the dashboard config. |
 | **Expected write tool missing** | By design — hosted MCP does not expose write tools. |
-| **Docs still show placeholders** | Select a stack with MCP enabled and refresh; JWT cookie only includes MCP fields when the feature is on. |
+| **Docs still show placeholders** | Select a stack with MCP enabled under **Settings → Access**, then refresh. |
 
 ### Next steps
 

--- a/src/pages/opensearch-api/hosted-mcp.mdx
+++ b/src/pages/opensearch-api/hosted-mcp.mdx
@@ -1,7 +1,7 @@
 ---
 title: Hosted OpenSearch MCP
 metaTitle: Hosted OpenSearch MCP for Cursor and Claude on Logit.io
-description: Connect Cursor or Claude Desktop to your Logit.io stack with hosted, read-only OpenSearch MCP at {stackId}-mcp.logit.io. Business and Custom plans.
+description: Connect Cursor or Claude Desktop to your Logit.io stack with hosted, read-only OpenSearch MCP at {stackId}-mcp.logit.io. Log Management and Custom plans.
 stackTypes: logs, opensearch
 ---
 
@@ -16,7 +16,7 @@ Public URL:
 ```
 
 <Callout type="info">
-Available on **Business** and **Custom** plans. MCP uses a **dedicated API key**, separate from your OpenSearch HTTP API key on `{stack-id}-es.logit.io`.
+Available on **Log Management** and **Custom** plans. MCP uses a **dedicated API key**, separate from your OpenSearch HTTP API key on `{stack-id}-es.logit.io`.
 </Callout>
 
 <Callout type="info">
@@ -34,7 +34,7 @@ MCP is not a substitute for the full OpenSearch REST API. For programmatic write
 
 ### Prerequisites
 
-1. Account on a **Business** or **Custom** plan.
+1. Account on a **Log Management** or **Custom** plan.
 2. A Logs or OpenSearch stack.
 3. Permission to enable MCP on the stack (stack administrator or account owner/admin).
 
@@ -91,7 +91,7 @@ Claude Desktop uses the same JSON shape. Paste the config from **Settings → En
 | --- | --- |
 | **Write operations** | Not available — MCP is always read-only |
 | **Credentials** | Dedicated `{stack-id}-mcp` username + MCP API key; do not reuse the `-es` stack API key |
-| **Plan** | Business and Custom only |
+| **Plan** | Log Management and Custom |
 | **Scope** | One MCP endpoint per stack; enable separately on each stack you need |
 
 ### Troubleshooting

--- a/src/pages/opensearch-api/user-credentials.mdx
+++ b/src/pages/opensearch-api/user-credentials.mdx
@@ -20,7 +20,7 @@ Available on **Business** and **Custom** plans. The stack must use the OpenSearc
 </Callout>
 
 <Callout type="info">
-When signed in, examples auto-fill `@esUser.*` **only if** the feature is enabled on your selected stack **and** you have opted in from Profile (or you are viewing service-account docs separately). Until then, placeholder text remains.
+When signed in, examples auto-fill `@esUser.*` when the feature is enabled on your selected stack and you have opted in from Profile (or when viewing service-account docs).
 </Callout>
 
 ### Choose this endpoint when

--- a/src/pages/opensearch/connect-to-opensearch-cluster.mdx
+++ b/src/pages/opensearch/connect-to-opensearch-cluster.mdx
@@ -47,7 +47,7 @@ If you have not yet created an OpenSearch Cluster, please see our guide on [Crea
   These credentials use **Basic (username and password)** authentication. Your stack may also use **API key** mode — switch on the Endpoints page if needed. See **[OpenSearch REST API](/opensearch-api)** for auth modes, API guides, and examples.
 
   <Callout type="info">
-  **Advanced access:** enable [OpenSearch API (user credentials)](/opensearch-api/user-credentials) for Teams role-scoped REST access on Business / Custom (`{stack-id}-es-user.logit.io`), or [Hosted OpenSearch MCP](/opensearch-api/hosted-mcp) for read-only Cursor / Claude on Log Management and Custom (`{stack-id}-mcp.logit.io`). Enable both from stack **Settings → Access**.
+  **Advanced access:** enable [OpenSearch API (user credentials)](/opensearch-api/user-credentials) for Teams role-scoped REST access on Business / Custom (`{stack-id}-es-user.logit.io`), or [Hosted OpenSearch MCP](/opensearch-api/hosted-mcp) for read-only Cursor / Claude on Log Management and Custom (`{stack-id}-mcp.logit.io`). Enable each applicable method independently under stack **Settings → Access**.
   </Callout>
 
   ### Cluster Settings

--- a/src/pages/opensearch/connect-to-opensearch-cluster.mdx
+++ b/src/pages/opensearch/connect-to-opensearch-cluster.mdx
@@ -47,7 +47,7 @@ If you have not yet created an OpenSearch Cluster, please see our guide on [Crea
   These credentials use **Basic (username and password)** authentication. Your stack may also use **API key** mode — switch on the Endpoints page if needed. See **[OpenSearch REST API](/opensearch-api)** for auth modes, API guides, and examples.
 
   <Callout type="info">
-  **Advanced access (Business / Custom):** enable [OpenSearch API (user credentials)](/opensearch-api/user-credentials) for Teams role-scoped REST access (`{stack-id}-es-user.logit.io`), or [Hosted OpenSearch MCP](/opensearch-api/hosted-mcp) for read-only Cursor / Claude (`{stack-id}-mcp.logit.io`). Enable both from stack **Settings → Access**.
+  **Advanced access:** enable [OpenSearch API (user credentials)](/opensearch-api/user-credentials) for Teams role-scoped REST access on Business / Custom (`{stack-id}-es-user.logit.io`), or [Hosted OpenSearch MCP](/opensearch-api/hosted-mcp) for read-only Cursor / Claude on Log Management and Custom (`{stack-id}-mcp.logit.io`). Enable both from stack **Settings → Access**.
   </Callout>
 
   ### Cluster Settings


### PR DESCRIPTION
## Summary
- Hosted OpenSearch MCP availability is now **Log Management and Custom** (was Business and Custom only)
- OpenSearch API user credentials remain **Business/Custom**
- Updated `hosted-mcp`, `connect`, OpenSearch cluster connect, and log-management REST API pages

## Test plan
- [ ] Spot-check `/docs/opensearch-api/hosted-mcp/` callout and prerequisites
- [ ] Confirm `connect` page separates MCP vs user-credentials plan gates
