### PR TITLE
Fix Ahrefs broken outlinks in docs content

### DIFF
--- a/src/pages/integrations/django.mdx
+++ b/src/pages/integrations/django.mdx
@@ -89,5 +89,5 @@ Follow the steps below to send your observability data to Logit.io
 ## More Help
 
 If you need any further assistance with migrating your Django 
-[application logs](https://logit.io/platform/logging/logging-as-a-service/application-logging/) to Logit.io 
+[application logs](https://logit.io/platform/logging/logging-as-a-service/) to Logit.io 
 we're here to help you get started. Just get in contact with our support team <IntercomButton text="via live chat" /> & we'll be happy to assist.

--- a/src/pages/integrations/elastic-agent.mdx
+++ b/src/pages/integrations/elastic-agent.mdx
@@ -144,7 +144,7 @@ If you need any further assistance with migrating your log data to ELK we're her
 
 ## Next steps
 
-- [Winlogbeat](/docs/integrations/winlogbeat/) — Windows event log shipping
+- [Winlogbeat](/integrations/winlogbeat/) — Windows event log shipping
 - [Log management](https://logit.io/platform/logging/log-management/) — managed Logstash + OpenSearch
 - [Log management pricing](https://logit.io/pricing/logs/) — plans from $25/mo and 14-day free trial
 - [Hosted OpenSearch](https://logit.io/platform/features/hosted-opensearch/) — OpenSearch clusters on Logit.io

--- a/src/pages/integrations/filebeat.mdx
+++ b/src/pages/integrations/filebeat.mdx
@@ -18,7 +18,7 @@ Follow the steps below to send your observability data to Logit.io
   ## Logs
 
   Filebeat is an open-source, lightweight log shipper designed to efficiently collect, process, and forward log data from local files 
-  to various destinations, including Logstash. To find out more about Filebeat click [here](../getting-started/getting-started-with-filebeat) 
+  to various destinations, including Logstash. To find out more about Filebeat click [here](../getting-started/filebeat) 
   to see our getting started guide.
 
   Below is a guide to walk you through installing Filebeat and sending system logs to Logit.io.

--- a/src/pages/integrations/golang.mdx
+++ b/src/pages/integrations/golang.mdx
@@ -105,7 +105,7 @@ Golang (also known as Go) is an open-source programming language created in 2009
 It forms the backbone of many platforms, including the core tools involved in 
 containerisation ([Kubernetes](/integrations/kubernetes) & [Docker](/integrations/docker)).
 
-While many [application logs](https://logit.io/platform/logging/logging-as-a-service/application-logging/) 
+While many [application logs](https://logit.io/platform/logging/logging-as-a-service/) 
 include a variety of statuses, Golang only records log messages when an error is generated. 
 Golang error logs include a variety of valuable data for troubleshooting, including 
 timestamps, contextual data, and what level of error has been encountered. 

--- a/src/pages/integrations/kubernetes.mdx
+++ b/src/pages/integrations/kubernetes.mdx
@@ -299,11 +299,11 @@ A common challenge for effective Kubernetes log aggregation is that during spike
 without a scalable logging solution such as Logit.io. Our platform also provides log tailing for real-time monitoring of your Kubernetes metrics. 
 
 Logit.io's [container monitoring](https://logit.io/solutions/monitoring/container-monitoring/) platform is built to collect, parse, and transform 
-[application logs](https://logit.io/platform/logging/logging-as-a-service/application-logging/) from your Kubernetes clusters within a few steps 
+[application logs](https://logit.io/platform/logging/logging-as-a-service/) from your Kubernetes clusters within a few steps 
 using the power of the managed Elastic Stack. 
 
 Monitor across 1,000s of containers, layers, logs levels, and data types, in one 
-[centralised logging platform](https://logit.io/platform/logging/logging-as-a-service/centralised-logging/) & save hours on monthly maintenance 
+[centralised logging platform](https://logit.io/platform/logging/logging-as-a-service/) & save hours on monthly maintenance 
 to support the ELK Stack.
 
 If you need any further help with migrating your Kubernetes log files using Filebeat we're here to help. Feel free to reach 

--- a/src/pages/integrations/mulesoft.mdx
+++ b/src/pages/integrations/mulesoft.mdx
@@ -101,7 +101,7 @@ Mule's technology has allowed them to become a market leader among other integra
 Their popularity continues to grow among IT teams prioritising digital transformation & modernisation within their 
 organisation.
 
-Their AnyPoint Platform generates both runtime & [application logs](https://logit.io/platform/logging/logging-as-a-service/application-logging/) 
+Their AnyPoint Platform generates both runtime & [application logs](https://logit.io/platform/logging/logging-as-a-service/) 
 to help users troubleshoot activity from the MuleSoft server. These can be shipped to the Elastic Stack & visualised in Kibana 
 to help administrators monitor errors, create dashboards & visualisations, as well as alert on irregularities in application 
 activity.  

--- a/src/pages/integrations/nlog.mdx
+++ b/src/pages/integrations/nlog.mdx
@@ -220,7 +220,7 @@ NLog is able to note a variety of log severities including (by descending priori
 `Fatal`, `Error`, `Warn`, `Info`, `Debug` & `Trace`.
 
 While NLog itself is a logging platform, the service also creates internal 
-[application logs](https://logit.io/platform/logging/logging-as-a-service/application-logging/) of its 
+[application logs](https://logit.io/platform/logging/logging-as-a-service/) of its 
 own that many users find extremely hard to troubleshoot & parse without the use of a tool like Hosted Logstash. 
 
 Our platform offers Hosted Logstash alongside Elasticsearch & Kibana to help 

--- a/src/pages/integrations/prometheus.mdx
+++ b/src/pages/integrations/prometheus.mdx
@@ -239,4 +239,4 @@ Feel free to get in contact with our support team by sending us a message via <I
 - [Hosted Prometheus](https://logit.io/platform/features/hosted-prometheus/) — managed Prometheus on Logit.io
 - [Grafana demo](https://logit.io/platform/features/grafana/grafana-demo/) — visualize metrics in hosted Grafana
 - [Metrics pricing](https://logit.io/pricing/metrics/) — plans and 14-day free trial
-- [Getting started: Grafana dashboards](/docs/getting-started/grafana-dashboards/) — build dashboards on your metrics stack
+- [Getting started: Grafana dashboards](/getting-started/grafana-dashboards/) — build dashboards on your metrics stack

--- a/src/pages/integrations/rancher.mdx
+++ b/src/pages/integrations/rancher.mdx
@@ -87,7 +87,7 @@ were acquired by SUSE & as a result of this acquisition have become one of
 the world's biggest companies powering digital transformation.
 
 If you don't have centralized logging for managing your Rancher-server logs it 
-can be difficult to [tail logs](https://logit.io/solutions/live-tail-hosted-logtrail/) 
+can be difficult to [tail logs](https://logit.io/platform/features/live-tail-hosted-logtrail/) 
 reliability. As your container base grows in size they'll often become a lot more 
 complicated to troubleshoot efficiently. Without the addition of a monitoring solution, 
 identifying errors proactively & setting alerts on predefined conditions can 

--- a/src/pages/integrations/telegraf.mdx
+++ b/src/pages/integrations/telegraf.mdx
@@ -8,7 +8,7 @@ sslPortType: beats-ssl
 tags: Telegraf, Metrics, Telemetry, OpenTelemetry, Health, Instrumentation, Monitoring, Performance
 ---
 
-You can find out more about Telegraf in our getting started guide [here](..\getting-started\telegraf.mdx). 
+You can find out more about Telegraf in our getting started guide [here](../getting-started/telegraf). 
 To learn how to install Telegraf and configure the output plugin to send metrics to your Logit.io stack, follow the steps below. 
 You will need to use a specific integration guide for the type of metrics you want to send in order to configure Telegraf.
 
@@ -27,7 +27,7 @@ You will need to use a specific integration guide for the type of metrics you wa
   The configuration file that is installed with Telegraf is thousands of lines long, and supports many different
   input plugins. You can find the recommended inputs configuration in the documentation for the
   type of metrics you want to send. For example, if you are sending Nginx metrics to Logit.io, you can find the 
-  instructions [here](..\integrations\nginx.mdx).
+  instructions [here](./nginx).
 
   ### Example Telegraf configuration file
   

--- a/src/pages/integrations/winlogbeat.mdx
+++ b/src/pages/integrations/winlogbeat.mdx
@@ -61,5 +61,5 @@ Winlogbeat is a Windows-specific event-log shipping agent. Use it for security l
 - [Event log analyser](https://logit.io/solutions/analysis/event-log-analyser/) — Windows event / SIEM workflows on Logit.io
 - [SIEM as a Service](https://logit.io/platform/observability/siem-as-a-service/) — security logging and threat hunting
 - [Log management pricing](https://logit.io/pricing/logs/) — plans from $25/mo and 14-day free trial
-- [Elastic Agent](/docs/integrations/elastic-agent/) — unified logs and metrics shipping
+- [Elastic Agent](/integrations/elastic-agent/) — unified logs and metrics shipping
 

--- a/src/pages/log-management/opensearch/index-management/listing-indexes.mdx
+++ b/src/pages/log-management/opensearch/index-management/listing-indexes.mdx
@@ -62,7 +62,7 @@ support team <IntercomButton text="via live chat" /> for further assistance.
 
 ## Next steps
 
-- [Index patterns](/docs/log-management/opensearch/index-management/index-patterns/) — create patterns for search and dashboards
-- [Index templates](/docs/log-management/opensearch/index-management/index-templates/) — control mappings and settings for new indexes
-- [Export search results](/docs/log-management/opensearch/searching/exporting-search-results/) — download query results as CSV or JSON
+- [Index patterns](/log-management/opensearch/index-management/index-patterns/) — create patterns for search and dashboards
+- [Index templates](/log-management/opensearch/index-management/index-templates/) — control mappings and settings for new indexes
+- [Export search results](/log-management/opensearch/searching/exporting-search-results/) — download query results as CSV or JSON
 - [Log management pricing](https://logit.io/pricing/logs/) — plans from $25/mo with a 14-day free trial


### PR DESCRIPTION
## Summary
- Retarget deleted LPaaS child URLs (`application-logging`, `centralised-logging`) to `/platform/logging/logging-as-a-service/`
- Retarget live-tail links to `/platform/features/live-tail-hosted-logtrail/`
- Fix Filebeat getting-started path (`getting-started-with-filebeat` → `filebeat`)
- Remove leading `/docs` from in-docs links that rendered as `/docs/docs/...` 404s (Prometheus, Winlogbeat, Elastic Agent, listing-indexes)

Delivery card: https://github.com/logit-io/marketing/issues/1208
Companion marketing PR: https://github.com/logit-io/marketing/pull/1209

## Test plan
- [ ] After docs deploy, kubernetes/filebeat no longer links to getting-started-with-filebeat 404
- [ ] Prometheus "Grafana dashboards" link is `/docs/getting-started/grafana-dashboards/` (not `/docs/docs/...`)
- [ ] Winlogbeat Elastic Agent link is `/docs/integrations/elastic-agent/`
- [ ] Kubernetes/Django/etc. marketing hub links return 200 (after marketing redirect fix is also live)