### PR TITLE
Deep-link adding-inputs docs to dashboard add-input wizard

### DIFF
--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-amazon-s3-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-amazon-s3-input.mdx
@@ -7,7 +7,11 @@ stackTypes: logs
 
 # How to add an Amazon S3 Input to your Log Stack
 
-To set up the Amazon S3 input for your Logstash stack, follow these steps:
+If you are signed in, open the Amazon S3 configure form for your Log stack:
+
+<ConfigureInputButton stackType="logs" utmMedium="docs" utmCampaign="add-amazon-s3-input" input="s3" buttonText="Amazon S3 Input" />
+
+Or configure it manually:
 
 1. Navigate to `Logstash Inputs` settings.
 2. Click on the "Add New Input" button in the Logstash configuration wizard.
@@ -24,8 +28,8 @@ To set up the Amazon S3 input for your Logstash stack, follow these steps:
    - **Tags:** Assign tags to your events (comma-separated).
    - **Type:** Add a type field to all events handled by this input.
    - **Add Field:** Include additional fields to the events. You can add multiple key-value pairs.
-5. Click the "Configure Input" button to save the Amazon S3 input configuration.
-6. Click "Cancel" to discard changes.
+6. Click the "Configure Input" button to save the Amazon S3 input configuration.
+7. Click "Cancel" to discard changes.
 
 This guide provides a step-by-step process for configuring an Amazon S3 input in Logstash. 
 Adjust the values based on your specific use case and preferences.

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-azure-event-hub-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-azure-event-hub-input.mdx
@@ -7,7 +7,11 @@ stackTypes: logs
 
 # How to add an Azure Event Hub Input to your Log Stack
 
-To configure the Azure Event Hub input in your Logstash stack, follow these steps:
+If you are signed in, open the Azure Event Hub configure form for your Log stack:
+
+<ConfigureInputButton stackType="logs" utmMedium="docs" utmCampaign="add-azure-event-hub-input" input="azure" buttonText="Azure Event Hub Input" />
+
+Or configure it manually:
 
 1. Navigate to `Logstash Inputs` settings.
 2. Click on the "Add New Input" button in the Logstash configuration wizard.
@@ -24,8 +28,8 @@ To configure the Azure Event Hub input in your Logstash stack, follow these step
    - **Tags:** Assign tags to your events (comma-separated).
    - **Type:** Add a type field to all events handled by this input.
    - **Add Field:** Include additional fields to the events. You can add multiple key-value pairs.
-5. Click the "Configure Input" button to save the Azure Event Hub input configuration.
-6. Click "Cancel" to discard changes.
+6. Click the "Configure Input" button to save the Azure Event Hub input configuration.
+7. Click "Cancel" to discard changes.
 
 This guide provides a step-by-step process for configuring an Azure Event Hub input in Logstash. 
 Adjust the values based on your specific use case and preferences.

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-beats-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-beats-input.mdx
@@ -7,7 +7,12 @@ stackTypes: logs
 
 # How to add a Beats Input to your Log Stack
 
-To configure the Beats input in your Logstash stack, follow these steps:
+If you are signed in, open the Beats configure form for your Log stack:
+
+<ConfigureInputButton stackType="logs" utmMedium="docs" utmCampaign="add-beats-input" input="beats" buttonText="Beats Input" />
+<ConfigureInputButton stackType="logs" utmMedium="docs" utmCampaign="add-beats-ssl-input" input="beats-ssl" buttonText="Beats SSL Input" />
+
+Or configure it manually:
 
 1. Navigate to `Logstash Inputs` settings.
 2. Click on the "Add New Input" button.

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-gelf-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-gelf-input.mdx
@@ -7,7 +7,12 @@ stackTypes: logs
 
 # How to add a GELF Input to your Log Stack
 
-To set up the GELF input in your Logstash stack, follow these steps:
+If you are signed in, open the GELF configure form for your Log stack (choose TCP or UDP):
+
+<ConfigureInputButton stackType="logs" utmMedium="docs" utmCampaign="add-gelf-tcp-input" input="gelf" protocol="tcp" buttonText="GELF TCP Input" />
+<ConfigureInputButton stackType="logs" utmMedium="docs" utmCampaign="add-gelf-udp-input" input="gelf" protocol="udp" buttonText="GELF UDP Input" />
+
+Or configure it manually:
 
 1. Navigate to `Logstash Inputs` settings.
 2. Click on the "Add New Input" button.

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-google-cloud-storage-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-google-cloud-storage-input.mdx
@@ -7,7 +7,11 @@ stackTypes: logs
 
 # How to add a Google Cloud Storage Input to your Log Stack
 
-To configure the Google Cloud Storage input in your Logstash stack, follow these steps:
+If you are signed in, open the Google Cloud Storage configure form for your Log stack:
+
+<ConfigureInputButton stackType="logs" utmMedium="docs" utmCampaign="add-google-cloud-storage-input" input="googlecloudstorage" buttonText="Google Cloud Storage Input" />
+
+Or configure it manually:
 
 1. Navigate to `Logstash Inputs` settings.
 2. Click on the "Add New Input" button in the Logstash configuration wizard.

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-google-pubsub-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-google-pubsub-input.mdx
@@ -7,7 +7,11 @@ stackTypes: logs
 
 # How to add a Google Pub/Sub Input to your Log Stack
 
-To configure the Google Pub/Sub input in your Logstash stack, follow these steps:
+If you are signed in, open the Google Pub/Sub configure form for your Log stack:
+
+<ConfigureInputButton stackType="logs" utmMedium="docs" utmCampaign="add-google-pubsub-input" input="googlepubsub" buttonText="Google Pub/Sub Input" />
+
+Or configure it manually:
 
 1. Navigate to `Logstash Inputs` settings.
 2. Click on the "Add New Input" button in the Logstash configuration wizard.

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-http-ssl-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-http-ssl-input.mdx
@@ -7,7 +7,11 @@ stackTypes: logs
 
 # How to add a HTTP SSL Input to your Log Stack
 
-To set up the HTTP-SSL input in your Logstash stack, follow these steps:
+If you are signed in, open the HTTP-SSL configure form for your Log stack:
+
+<ConfigureInputButton stackType="logs" utmMedium="docs" utmCampaign="add-http-ssl-input" input="http-ssl" buttonText="HTTP SSL Input" />
+
+Or configure it manually:
 
 1. Navigate to `Logstash Inputs` settings.
 2. Click on the "Add New Input" button.

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-sqs-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-sqs-input.mdx
@@ -7,7 +7,11 @@ stackTypes: logs
 
 # How to add a SQS Input to your Log Stack
 
-To configure the SQS input in your Logstash stack, follow these steps:
+If you are signed in, open the SQS configure form for your Log stack:
+
+<ConfigureInputButton stackType="logs" utmMedium="docs" utmCampaign="add-sqs-input" input="sqs" buttonText="SQS Input" />
+
+Or configure it manually:
 
 1. Navigate to `Logstash Inputs` settings.
 2. Click on the "Add New Input" button in the Logstash configuration wizard.
@@ -39,8 +43,8 @@ To configure the SQS input in your Logstash stack, follow these steps:
    - **Tags:** Assign tags to your events (comma-separated).
    - **Type:** Add a type field to all events handled by this input.
    - **Add Field:** Include additional fields to the events. You can add multiple key-value pairs.
-5. Click the "Configure Input" button to save the SQS input configuration.
-6. Click "Cancel" to discard changes.
+6. Click the "Configure Input" button to save the SQS input configuration.
+7. Click "Cancel" to discard changes.
 
 This guide provides a step-by-step process for configuring an SQS input in Logstash. 
 Adjust the values based on your specific use case and preferences.

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-syslog-ssl-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-syslog-ssl-input.mdx
@@ -7,7 +7,11 @@ stackTypes: logs
 
 # How to add a Syslog SSL Input to your Log Stack
 
-To configure the Syslog-SSL input in your Logstash stack, follow these steps:
+If you are signed in, open the Syslog-SSL configure form for your Log stack:
+
+<ConfigureInputButton stackType="logs" utmMedium="docs" utmCampaign="add-syslog-ssl-input" input="syslog-ssl" buttonText="Syslog SSL Input" />
+
+Or configure it manually:
 
 1. Navigate to `Logstash Inputs` settings.
 2. Click on the "Add New Input" button.

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-syslog-tcp-udp-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-syslog-tcp-udp-input.mdx
@@ -7,18 +7,23 @@ stackTypes: logs
 
 # How to add a Syslog TCP or UDP Input to your Log Stack
 
-To set up the Syslog input in your Logstash stack, follow these steps:
+If you are signed in, open the Syslog configure form for your Log stack (choose TCP or UDP):
+
+<ConfigureInputButton stackType="logs" utmMedium="docs" utmCampaign="add-syslog-tcp-input" input="syslog" protocol="tcp" buttonText="Syslog TCP Input" />
+<ConfigureInputButton stackType="logs" utmMedium="docs" utmCampaign="add-syslog-udp-input" input="syslog" protocol="udp" buttonText="Syslog UDP Input" />
+
+Or configure it manually:
 
 1. Navigate to `Logstash Inputs` settings.
 2. Click on the "Add New Input" button.
 3. Choose the "Syslog" option you require from the list of available input types.
 4. The following configuration details are optional, only add if required:
-   - **Display Name:** Assign a name for the HTTP-SSL input.
+   - **Display Name:** Assign a name for the Syslog input.
    - **Display Description:** Provide a description for easy identification.
    - **Tags:** Tag your events with arbitrary values (comma-separated).
    - **Type:** Include a type field in all events processed by this input.
    - **Add Field:** Append extra fields to your events by entering key-value pairs.
-5. Click the "Configure Input" button to save the HTTP-SSL input configuration.
+5. Click the "Configure Input" button to save the Syslog input configuration.
 6. Click "Cancel" to discard changes.
 
 This guide provides a step-by-step process for configuring a Syslog input in Logstash. 

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-tcp-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-tcp-input.mdx
@@ -7,7 +7,11 @@ stackTypes: logs
 
 # How to add a TCP Input to your Log Stack
 
-To set up the Syslog input in your Logstash stack, follow these steps:
+If you are signed in, open the TCP configure form for your Log stack:
+
+<ConfigureInputButton stackType="logs" utmMedium="docs" utmCampaign="add-tcp-input" input="tcp" buttonText="TCP Input" />
+
+Or configure it manually:
 
 1. Navigate to `Logstash Inputs` settings.
 2. Click on the "Add New Input" button.

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-tcp-ssl-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-tcp-ssl-input.mdx
@@ -7,7 +7,11 @@ stackTypes: logs
 
 # How to add a TCP SSL Input to your Log Stack
 
-To configure the TCP-SSL input in your Logstash stack, follow these steps:
+If you are signed in, open the TCP-SSL configure form for your Log stack:
+
+<ConfigureInputButton stackType="logs" utmMedium="docs" utmCampaign="add-tcp-ssl-input" input="tcp-ssl" buttonText="TCP SSL Input" />
+
+Or configure it manually:
 
 1. Navigate to `Logstash Inputs` settings.
 2. Click on the "Add New Input" button in the Logstash configuration wizard.

--- a/src/pages/log-management/ingestion-pipeline/adding-inputs/add-udp-input.mdx
+++ b/src/pages/log-management/ingestion-pipeline/adding-inputs/add-udp-input.mdx
@@ -7,7 +7,11 @@ stackTypes: logs
 
 # How to add a UDP Input to your Log Stack
 
-To set up the Syslog input in your Logstash stack, follow these steps:
+If you are signed in, open the UDP configure form for your Log stack:
+
+<ConfigureInputButton stackType="logs" utmMedium="docs" utmCampaign="add-udp-input" input="udp" buttonText="UDP Input" />
+
+Or configure it manually:
 
 1. Navigate to Stack Settings > Logstash Inputs.
 2. Click on the "Add New Input" button.


### PR DESCRIPTION
## Summary
- Add stack-aware `ConfigureInputButton` CTAs to all Log Management adding-inputs guides
- Signed-in users deep-link to `/logs-settings/add-input/{input}` for their stack; signed-out users get Dashboard fallback
- GELF / Syslog TCP|UDP and Beats / Beats SSL offer protocol- or variant-specific buttons

Delivery card: https://github.com/logit-io/docs-content/issues/129
Companion docs app PR: https://github.com/logit-io/docs/pull/178

## Test plan
- [ ] Signed in on docs: open e.g. `/docs/log-management/ingestion-pipeline/adding-inputs/add-http-ssl-input/` and confirm Configure lands on HTTP SSL add-input for the selected stack
- [ ] Signed out: confirm Go to Dashboard CTA
- [ ] Spot-check GELF TCP/UDP and Syslog TCP/UDP protocol links
- [ ] Spot-check Beats + Beats SSL buttons